### PR TITLE
Feat: Update Regionalization Button and Regionalization Bar to show the postal code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `RegionalizationButton` and `RegionalizationBar` to show the postal code (#7)
+- Update `RegionalizationButton` and `RegionalizationBar` to show the postal code ([#7](https://github.com/vtex-sites/nextjs.store/pull/7))
 - Migrates to Next.JS (#475)
 - Applies new local tokens to `ProductShelf` component (#464)
 - Adds Storybook configs (#463)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - New items to the checklist of the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))
 - Integrates with search.query event api (#2)
 - Applies new local tokens to `Badge` (#462)
@@ -15,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applies new local tokens to `Quantity Selector` (#448)
 
 ### Changed
+
+- Update `RegionalizationButton` and `RegionalizationBar` to show the postal code (#7)
 - Migrates to Next.JS (#475)
 - Applies new local tokens to `ProductShelf` component (#464)
 - Adds Storybook configs (#463)

--- a/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
+++ b/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
@@ -1,28 +1,28 @@
 import type { HTMLAttributes } from 'react'
+import { useSession } from '@faststore/sdk'
 
+import { useModal } from 'src/sdk/ui/modal/Provider'
 import Button from 'src/components/ui/Button'
 import Icon from 'src/components/ui/Icon'
-import { useModal } from 'src/sdk/ui/modal/Provider'
 
 interface RegionalizationBarProps extends HTMLAttributes<HTMLDivElement> {
-  content?: string
   classes: string
 }
 
 export default function RegionalizationBar({
-  content,
   classes,
   ...otherProps
 }: RegionalizationBarProps) {
   const { setIsRegionalizationModalOpen } = useModal()
+  const { postalCode } = useSession()
 
   return (
     <div data-fs-regionalization-bar className={classes} {...otherProps}>
       <Button onClick={() => setIsRegionalizationModalOpen(true)}>
         <Icon name="MapPin" width={24} height={24} />
-        {content ? (
+        {postalCode ? (
           <>
-            <span>{content}</span>
+            <span>{postalCode}</span>
             <span>Edit</span>
           </>
         ) : (

--- a/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
+++ b/src/components/regionalization/RegionalizationBar/RegionalizationBar.tsx
@@ -1,9 +1,9 @@
 import type { HTMLAttributes } from 'react'
 import { useSession } from '@faststore/sdk'
 
-import { useModal } from 'src/sdk/ui/modal/Provider'
 import Button from 'src/components/ui/Button'
 import Icon from 'src/components/ui/Icon'
+import { useModal } from 'src/sdk/ui/modal/Provider'
 
 interface RegionalizationBarProps extends HTMLAttributes<HTMLDivElement> {
   classes: string

--- a/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
+++ b/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
@@ -1,9 +1,9 @@
 import type { HTMLAttributes } from 'react'
 import { useSession } from '@faststore/sdk'
 
-import { useModal } from 'src/sdk/ui/modal/Provider'
 import Button from 'src/components/ui/Button'
 import Icon from 'src/components/ui/Icon'
+import { useModal } from 'src/sdk/ui/modal/Provider'
 
 interface RegionalizationButtonProps extends HTMLAttributes<HTMLDivElement> {
   classes: string

--- a/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
+++ b/src/components/regionalization/RegionalizationButton/RegionalizationButton.tsx
@@ -1,20 +1,20 @@
 import type { HTMLAttributes } from 'react'
+import { useSession } from '@faststore/sdk'
 
+import { useModal } from 'src/sdk/ui/modal/Provider'
 import Button from 'src/components/ui/Button'
 import Icon from 'src/components/ui/Icon'
-import { useModal } from 'src/sdk/ui/modal/Provider'
 
 interface RegionalizationButtonProps extends HTMLAttributes<HTMLDivElement> {
-  content?: string
   classes: string
 }
 
 export default function RegionalizationButton({
-  content,
   classes,
   ...otherProps
 }: RegionalizationButtonProps) {
   const { setIsRegionalizationModalOpen } = useModal()
+  const { postalCode } = useSession()
 
   return (
     <div data-fs-regionalization-button className={classes} {...otherProps}>
@@ -25,13 +25,7 @@ export default function RegionalizationButton({
         iconPosition="left"
         onClick={() => setIsRegionalizationModalOpen(true)}
       >
-        {content ? (
-          <>
-            <span>{content}</span>
-          </>
-        ) : (
-          <span>Set your location</span>
-        )}
+        <span>{postalCode ?? 'Set your location'}</span>
       </Button>
     </div>
   )


### PR DESCRIPTION
Applies patch from https://github.com/vtex-sites/base.store/pull/495

## What's the purpose of this pull request?

Update Regionalization Button and Regionalization Bar to show the last postal code saved, instead of receiving a `content` prop.

![image](https://user-images.githubusercontent.com/22377378/164786815-d827a559-91a7-41f8-897a-c1ef966bc1cd.png)

![image](https://user-images.githubusercontent.com/22377378/164786782-aec331e0-c7d3-44dd-9110-85c161f73288.png)

## How to test it?

1- Set a valid postal code in `RegionalizationInput` 
2- Press "enter" key
3- Push the close button.

## References

- [Base store's PR](https://github.com/vtex-sites/base.store/pull/495)
- [Postal Code Bar's original code](https://github.com/vtex-sites/base.store/pull/424)

## Checklist

- [x] CHANGELOG entry added
