### PR TITLE
feat: Adds new tokens to Select

### DIFF
--- a/src/components/search/Sort/Sort.tsx
+++ b/src/components/search/Sort/Sort.tsx
@@ -25,7 +25,7 @@ function Sort() {
     <Select
       id="sort-select"
       className="sort / text__title-mini-alt"
-      labelText="Sort by"
+      label="Sort by"
       options={OptionsMap}
       onChange={(e) => setSort(keys[e.target.selectedIndex])}
       value={sort}

--- a/src/components/ui/Select/Select.stories.tsx
+++ b/src/components/ui/Select/Select.stories.tsx
@@ -1,0 +1,23 @@
+import type { SelectProps } from '.'
+import Select from '.'
+
+const story = {
+  component: Select,
+  title: 'Atoms/Select',
+}
+
+const Template = ({ ...args }: SelectProps) => <Select {...args} />
+
+export const Default = Template.bind({})
+
+Default.args = {
+  id: 'select',
+  options: {
+    name_asc: 'Name, A-Z',
+    name_desc: 'Name, Z-A',
+  },
+  label: 'Label',
+  disabled: false,
+}
+
+export default story

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -1,9 +1,9 @@
-import { Select as UISelect } from '@faststore/ui'
+import { Select as UISelect, Label as UILabel } from '@faststore/ui'
 import type { SelectProps } from '@faststore/ui'
 
 import Icon from 'src/components/ui/Icon'
 
-interface UISelectProps extends SelectProps {
+export interface UISelectProps extends SelectProps {
   /*
    * Redefines the id property to be required when using the Select component. The
    * id will be used to link the UISelect component and its label.
@@ -19,7 +19,7 @@ interface UISelectProps extends SelectProps {
    * Specifies the text that will be displayed in the label right next to the Select.
    * If omitted, the label will not be rendered.
    */
-  labelText?: string
+  label?: string
 }
 
 export default function Select({
@@ -27,20 +27,26 @@ export default function Select({
   className,
   options,
   onChange,
-  labelText,
+  label,
   value,
   'aria-label': ariaLabel,
   testId,
+  ...otherProps
 }: UISelectProps) {
   return (
-    <div data-select className={className}>
-      {labelText && <label htmlFor={id}>{labelText}</label>}
+    <div data-fs-select className={className}>
+      {label && (
+        <UILabel data-fs-select-label htmlFor={id}>
+          {label}
+        </UILabel>
+      )}
       <UISelect
         data-testid={testId}
         onChange={onChange}
         value={value}
         aria-label={ariaLabel}
         id={id}
+        {...otherProps}
       >
         {Object.keys(options).map((key) => (
           <option key={key} value={key}>
@@ -48,7 +54,13 @@ export default function Select({
           </option>
         ))}
       </UISelect>
-      <Icon name="CaretDown" width={18} height={18} weight="bold" />
+      <Icon
+        data-fs-select-icon
+        name="CaretDown"
+        width={18}
+        height={18}
+        weight="bold"
+      />
     </div>
   )
 }

--- a/src/components/ui/Select/index.ts
+++ b/src/components/ui/Select/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Select'
+export type { UISelectProps as SelectProps } from './Select'

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './Select'

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -1,47 +1,77 @@
 @import "src/styles/scaffold";
 
-[data-select] {
+[data-fs-select] {
+  // --------------------------------------------------------
+  // Design Tokens for Select
+  // --------------------------------------------------------
+
+  // Default properties
+  --fs-select-height                      : var(--fs-spacing-6);
+  --fs-select-min-height                  : var(--fs-control-tap-size);
+  --fs-select-padding                     : var(--fs-spacing-1) var(--fs-spacing-5) var(--fs-spacing-1) var(--fs-spacing-2);
+
+  --fs-select-text-color                  : var(--fs-color-link);
+  --fs-select-border-radius               : var(--fs-border-radius-default);
+
+  --fs-select-bkg                         : transparent;
+  --fs-select-bkg-color-focus             : var(--fs-color-primary-bkg-light);
+  --fs-select-bkg-color-hover             : var(--fs-select-bkg-color-focus);
+
+  --fs-select-transition-timing           : var(--fs-transition-timing);
+  --fs-select-transition-property         : var(--fs-transition-property);
+  --fs-select-transition-function         : var(--fs-transition-function);
+
+  --fs-select-label-color                 : var(--fs-color-text-light);
+  --fs-select-label-margin-right          : var(--fs-spacing-1);
+
+  --fs-select-icon-position-right         : var(--fs-spacing-2);
+  --fs-select-icon-color                  : var(--fs-color-link);
+
+  // Disabled
+  --fs-select-disabled-text-color         : var(--fs-color-disabled-text);
+  --fs-select-disabled-text-opacity       : 1;
+
   position: relative;
   display: flex;
   align-items: center;
 
-  label {
-    margin-right: var(--fs-spacing-1);
-    color: var(--fs-color-text-light);
-  }
-
-  [data-store-select] {
-    padding: var(--fs-spacing-1) var(--fs-spacing-5) var(--fs-spacing-1) var(--fs-spacing-2);
-    color: var(--fs-color-link);
-    background: transparent;
+  select {
+    padding: var(--fs-select-padding);
+    color: var(--fs-select-text-color);
+    background: var(--fs-select-bkg);
     border: 0;
-    border-radius: var(--fs-border-radius-default);
+    border-radius: var(--fs-select-border-radius);
     box-shadow: 0;
-    transition: box-shadow .2s ease, background-color .2s ease;
+    transition: var(--fs-select-transition-property) var(--fs-select-transition-timing) var(--fs-select-transition-function);
     appearance: none;
 
     @include focus-ring-visible;
 
-    &:focus { background-color: var(--fs-color-primary-bkg-light); }
+    &:focus { background-color: var(--fs-select-bkg-color-focus); }
 
-    &:hover:not(:disabled) { background-color: var(--fs-color-primary-bkg-light); }
+    &:hover:not(:disabled) { background-color: var(--fs-select-bkg-color-hover); }
 
     &:disabled {
-      color: var(--fs-color-disabled-text);
+      color: var(--fs-select-disabled-text-color);
       cursor: not-allowed;
-      opacity: 1;
-      + svg { display: none; }
+      opacity: var(--fs-select-disabled-text-opacity);
+      + [data-fs-select-icon] { display: none; }
     }
 
-    @include media("<notebook") { min-height: var(--fs-control-tap-size); }
+    @include media("<notebook") { min-height: var(--fs-select-min-height); }
 
-    @include media(">=notebook") { height: var(--fs-spacing-6); }
+    @include media(">=notebook") { height: var(--fs-select-height); }
   }
+}
 
-  svg {
-    position: absolute;
-    right: var(--fs-spacing-2);
-    color: var(--fs-color-link);
-    pointer-events: none;
-  }
+[data-fs-select-label] {
+  margin-right: var(--fs-select-label-margin-right);
+  color: var(--fs-select-label-color);
+}
+
+[data-fs-select-icon] {
+  position: absolute;
+  right: var(--fs-select-icon-position-right);
+  color: var(--fs-select-icon-color);
+  pointer-events: none;
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Ported from `gatsby.store` repo: [feat: Adds new tokens to Select #17](https://github.com/vtex-sites/gatsby.store/pull/17)

This PR intends to add new tokens to the `Select` component using the [Theming Structure](https://github.com/vtex-sites/base.store/pull/407).

## How does it work?

This PR uses local variables to parameterize the `Select` properties, then connects these scoped tokens to the global ones.

### New global tokens:
None.

### New local tokens for `Select`:

#### Default properties:
| Local token | Default value/Global token linked |
| - | - | 
| `--fs-select-height` | `var(--fs-spacing-6)` |
| `--fs-select-min-height` | `var(--fs-control-tap-size)` |
| `--fs-select-padding` | `var(--fs-spacing-1) var(--fs-spacing-5) var(--fs-spacing-1) var(--fs-spacing-2)` |
|  |  |
| `--fs-select-text-color` | `var(--fs-color-link)` |
| `--fs-select-border-radius` | `var(--fs-border-radius-default)` |
|  |  |
| `--fs-select-bkg` | `transparent` |
| `--fs-select-bkg-color-focus` | `var(--fs-color-primary-bkg-light)` |
| `--fs-select-bkg-color-hover` | `var(--fs-select-bkg-color-focus)` |
|  |  |
| `--fs-select-transition-timing` | `var(--fs-transition-timing)` |
| `--fs-select-transition-property` | `var(--fs-transition-property)` |
| `--fs-select-transition-function` | `var(--fs-transition-function)` |
|  |  |
| `--fs-select-label-margin-right` | `var(--fs-spacing-1)` |
| `--fs-select-label-color` | `var(--fs-color-text-light)` |
|  |  |
| `--fs-select-icon-right` | `var(--fs-spacing-2)` |
| `--fs-select-icon-color` | `var(--fs-color-link)` |
|  |  |
| **Disabled:** | ----------------------------------- |
| `--fs-select-disabled-color` | `var(--fs-color-disabled-text)` |
| `--fs-select-disabled-opacity` | `1` |

## How to test it?

The `Select` component should look just as it was before these changes.

Right now, we have an error on Storybook that displays `Select` icon with the wrong style because it needs to have a wrapper to limit the input container. So it will be done in another bug task.

![Screen Shot 2022-05-02 at 18 03 16](https://user-images.githubusercontent.com/15722605/166327649-53297e0f-2132-4aa4-9a9a-7f3fc8195b5a.png)

## Checklist

- [ ] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [ ] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 


- PR description
- [x] Updated the Storybook - *if applicable*.
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.