### PR TITLE
feat: Adds new tokens to Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Applies new local tokens to `Select` ([#16](https://github.com/vtex-sites/nextjs.store/pull/16))
 - New items to the checklist of the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))
 - Integrates with search.query event api ([#2](https://www.github.com/vtex-sites/nextjs.store/pull/2))
 - Applies new local tokens to `Badge` ([#462](https://www.github.com/vtex-sites/base.store/pull/462))

--- a/src/components/search/Sort/Sort.tsx
+++ b/src/components/search/Sort/Sort.tsx
@@ -25,7 +25,7 @@ function Sort() {
     <Select
       id="sort-select"
       className="sort / text__title-mini-alt"
-      labelText="Sort by"
+      label="Sort by"
       options={OptionsMap}
       onChange={(e) => setSort(keys[e.target.selectedIndex])}
       value={sort}

--- a/src/components/ui/Link/Link.stories.tsx
+++ b/src/components/ui/Link/Link.stories.tsx
@@ -1,0 +1,71 @@
+import type { LinkProps } from '.'
+import Link from '.'
+
+const story = {
+  component: Link,
+  title: 'Atoms/Link',
+  argTypes: {
+    to: {
+      type: { name: 'string', required: true },
+    },
+    ref: {
+      table: {
+        disable: true,
+      },
+    },
+    as: {
+      table: {
+        disable: true,
+      },
+    },
+    inverse: {
+      control: 'boolean',
+      table: { defaultValue: false },
+    },
+  },
+}
+
+const Template = ({ inverse, ...args }: LinkProps) =>
+  inverse ? (
+    <div style={{ backgroundColor: '#171a1c', padding: '10px' }}>
+      <Link inverse {...args}>
+        Link Inverse
+      </Link>
+    </div>
+  ) : (
+    <Link {...args}>Link</Link>
+  )
+
+export const Default = Template.bind({})
+
+Default.args = {
+  to: '#',
+  variant: 'default',
+  inverse: false,
+}
+
+export const Display = Template.bind({})
+
+Display.args = {
+  to: '#',
+  variant: 'display',
+  inverse: false,
+}
+
+export const Footer = Template.bind({})
+
+Footer.args = {
+  to: '#',
+  variant: 'footer',
+  inverse: false,
+}
+
+export const Inline = Template.bind({})
+
+Inline.args = {
+  to: '#',
+  variant: 'inline',
+  inverse: false,
+}
+
+export default story

--- a/src/components/ui/Link/Link.tsx
+++ b/src/components/ui/Link/Link.tsx
@@ -1,22 +1,23 @@
 import { Link as UILink } from '@faststore/ui'
 import type { ElementType } from 'react'
-import type { LinkProps } from '@faststore/ui'
+import type { LinkProps as UILinkProps } from '@faststore/ui'
 
 import FrameworkLink from 'src/components/common/Link'
 
-type Variant = 'default' | 'display' | 'inline' | 'footer'
+type Variant = 'default' | 'display' | 'footer' | 'inline'
 
-type Props<T extends ElementType = typeof FrameworkLink> = LinkProps<T> & {
-  variant?: Variant
-  inverse?: boolean
-}
+export type LinkProps<T extends ElementType = typeof FrameworkLink> =
+  UILinkProps<T> & {
+    variant?: Variant
+    inverse?: boolean
+  }
 
 function Link<T extends ElementType = typeof FrameworkLink>({
   variant = 'default',
   inverse,
   href,
-  ...props
-}: Props<T>) {
+  ...otherProps
+}: LinkProps<T>) {
   return (
     <UILink
       as={FrameworkLink}
@@ -24,7 +25,7 @@ function Link<T extends ElementType = typeof FrameworkLink>({
       data-fs-link-variant={variant}
       data-fs-link-inverse={inverse}
       href={href}
-      {...props}
+      {...otherProps}
     />
   )
 }

--- a/src/components/ui/Link/index.ts
+++ b/src/components/ui/Link/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Link'
+export type { LinkProps } from './Link'

--- a/src/components/ui/Link/index.tsx
+++ b/src/components/ui/Link/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './Link'

--- a/src/components/ui/Link/link.scss
+++ b/src/components/ui/Link/link.scss
@@ -1,48 +1,96 @@
 @import "src/styles/scaffold";
 
+[data-fs-link] {
+  // --------------------------------------------------------
+  // Design Tokens for Link
+  // --------------------------------------------------------
+
+  // Default properties
+  --fs-link-min-width                  : auto;
+  --fs-link-min-height                 : var(--fs-link-min-width);
+  --fs-link-padding                    : var(--fs-spacing-2) var(--fs-spacing-0);
+
+  --fs-link-border-radius              : var(--fs-border-radius-default);
+
+  --fs-link-text-line-height           : 1.5;
+  --fs-link-text-color                 : var(--fs-color-link);
+  --fs-link-text-color-visited         : var(--fs-color-link-visited);
+  --fs-link-text-decoration            : none;
+  --fs-link-text-decoration-hover      : underline;
+
+  --fs-link-transition-function        : var(--fs-transition-function);
+  --fs-link-transition-property        : var(--fs-transition-property);
+  --fs-link-transition-timing          : var(--fs-transition-timing);
+
+  --fs-link-inverse-text-color         : var(--fs-color-link-inverse);
+  --fs-link-inverse-text-color-visited : var(--fs-link-inverse-text-color);
+
+  // Display
+  --fs-link-display-text-line-height   : var(--fs-link-text-line-height);
+  --fs-link-display-text-color         : var(--fs-color-text-display);
+  --fs-link-display-text-color-visited : var(--fs-link-display-text-color);
+
+  // Inline
+  --fs-link-inline-padding             : 0;
+  --fs-link-inline-text-decoration     : underline;
+
+  // Footer
+  --fs-link-footer-text-size           : var(--fs-text-size-1);
+  --fs-link-footer-text-color          : var(--fs-color-info-text);
+  --fs-link-footer-padding             : var(--fs-spacing-1) var(--fs-spacing-0);
+
+  // --------------------------------------------------------
+  // Structural Styles
+  // --------------------------------------------------------
+
+  min-width: var(--fs-link-min-width);
+  min-height: var(--fs-link-min-height);
+  padding: var(--fs-link-padding);
+  text-decoration: var(--fs-link-text-decoration);
+
+  &:hover { text-decoration: var(--fs-link-text-decoration-hover); }
+
+  &:visited { color: var(--fs-link-text-color-visited); }
+}
+
 a, [data-fs-link] {
-  border-radius: var(--fs-border-radius-default);
-  transition: box-shadow .5s ease;
+  border-radius: var(--fs-link-border-radius);
+  transition: var(--fs-link-transition-property) var(--fs-link-transition-timing) var(--fs-link-transition-function);
 
   @include focus-ring-visible;
 }
 
-[data-fs-link] {
-  min-width: auto;
-  min-height: auto;
-  padding: var(--fs-spacing-2) var(--fs-spacing-0);
-  text-decoration: none;
-  &:hover { text-decoration: underline; }
-  &:visited { color: var(--fs-color-link-visited); }
-}
-
-// Links ////////////////////////////
+// --------------------------------------------------------
+// Variants Styles
+// --------------------------------------------------------
 
 [data-fs-link-variant="default"] {
-  line-height: 1.5;
-  color: var(--fs-color-link);
+  line-height: var(--fs-link-text-line-height);
+  color: var(--fs-link-text-color);
 }
 
 [data-fs-link-variant="display"] {
-  line-height: 1.5;
-  color: var(--fs-color-text-display);
-  &:visited { color: var(--fs-color-text-display); }
+  line-height: var(--fs-link-display-text-line-height);
+  color: var(--fs-link-display-text-color);
+
+  &:visited { color: var(--fs-link-display-text-color-visited); }
 }
 
 [data-fs-link-variant="inline"] {
   display: inline-block;
-  padding: 0;
-  text-decoration: underline;
+  padding: var(--fs-link-inline-padding);
+  text-decoration: var(--fs-link-inline-text-decoration);
 }
 
 [data-fs-link-variant="footer"] {
-  font-size: var(--fs-text-size-1);
-  color: var(--fs-color-text);
+  font-size: var(--fs-link-footer-text-size);
+  color: var(--fs-link-footer-text-color);
 
-  @include media(">=notebook") { padding: var(--fs-spacing-1) var(--fs-spacing-0); }
+  @include media(">=notebook") { padding: var(--fs-link-footer-padding); }
 }
 
-[data-fs-link-inverse] {
-  color: var(--fs-color-link-inverse);
-  &:visited { color: var(--fs-color-link-inverse); }
+[data-fs-link-inverse="true"] {
+  color: var(--fs-link-inverse-text-color);
+
+  &:visited { color: var(--fs-link-inverse-text-color-visited); }
 }

--- a/src/components/ui/Select/Select.stories.tsx
+++ b/src/components/ui/Select/Select.stories.tsx
@@ -1,0 +1,23 @@
+import type { SelectProps } from '.'
+import Select from '.'
+
+const story = {
+  component: Select,
+  title: 'Atoms/Select',
+}
+
+const Template = ({ ...args }: SelectProps) => <Select {...args} />
+
+export const Default = Template.bind({})
+
+Default.args = {
+  id: 'select',
+  options: {
+    name_asc: 'Name, A-Z',
+    name_desc: 'Name, Z-A',
+  },
+  label: 'Label',
+  disabled: false,
+}
+
+export default story

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -1,9 +1,9 @@
-import { Select as UISelect } from '@faststore/ui'
+import { Select as UISelect, Label as UILabel } from '@faststore/ui'
 import type { SelectProps } from '@faststore/ui'
 
 import Icon from 'src/components/ui/Icon'
 
-interface UISelectProps extends SelectProps {
+export interface UISelectProps extends SelectProps {
   /*
    * Redefines the id property to be required when using the Select component. The
    * id will be used to link the UISelect component and its label.
@@ -19,7 +19,7 @@ interface UISelectProps extends SelectProps {
    * Specifies the text that will be displayed in the label right next to the Select.
    * If omitted, the label will not be rendered.
    */
-  labelText?: string
+  label?: string
 }
 
 export default function Select({
@@ -27,20 +27,26 @@ export default function Select({
   className,
   options,
   onChange,
-  labelText,
+  label,
   value,
   'aria-label': ariaLabel,
   testId,
+  ...otherProps
 }: UISelectProps) {
   return (
-    <div data-select className={className}>
-      {labelText && <label htmlFor={id}>{labelText}</label>}
+    <div data-fs-select className={className}>
+      {label && (
+        <UILabel data-fs-select-label htmlFor={id}>
+          {label}
+        </UILabel>
+      )}
       <UISelect
         data-testid={testId}
         onChange={onChange}
         value={value}
         aria-label={ariaLabel}
         id={id}
+        {...otherProps}
       >
         {Object.keys(options).map((key) => (
           <option key={key} value={key}>
@@ -48,7 +54,13 @@ export default function Select({
           </option>
         ))}
       </UISelect>
-      <Icon name="CaretDown" width={18} height={18} weight="bold" />
+      <Icon
+        data-fs-select-icon
+        name="CaretDown"
+        width={18}
+        height={18}
+        weight="bold"
+      />
     </div>
   )
 }

--- a/src/components/ui/Select/index.ts
+++ b/src/components/ui/Select/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Select'
+export type { UISelectProps as SelectProps } from './Select'

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './Select'

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -1,47 +1,77 @@
 @import "src/styles/scaffold";
 
-[data-select] {
+[data-fs-select] {
+  // --------------------------------------------------------
+  // Design Tokens for Select
+  // --------------------------------------------------------
+
+  // Default properties
+  --fs-select-height                      : var(--fs-spacing-6);
+  --fs-select-min-height                  : var(--fs-control-tap-size);
+  --fs-select-padding                     : var(--fs-spacing-1) var(--fs-spacing-5) var(--fs-spacing-1) var(--fs-spacing-2);
+
+  --fs-select-text-color                  : var(--fs-color-link);
+  --fs-select-border-radius               : var(--fs-border-radius-default);
+
+  --fs-select-bkg                         : transparent;
+  --fs-select-bkg-color-focus             : var(--fs-color-primary-bkg-light);
+  --fs-select-bkg-color-hover             : var(--fs-select-bkg-color-focus);
+
+  --fs-select-transition-timing           : var(--fs-transition-timing);
+  --fs-select-transition-property         : var(--fs-transition-property);
+  --fs-select-transition-function         : var(--fs-transition-function);
+
+  --fs-select-label-color                 : var(--fs-color-text-light);
+  --fs-select-label-margin-right          : var(--fs-spacing-1);
+
+  --fs-select-icon-position-right         : var(--fs-spacing-2);
+  --fs-select-icon-color                  : var(--fs-color-link);
+
+  // Disabled
+  --fs-select-disabled-text-color         : var(--fs-color-disabled-text);
+  --fs-select-disabled-text-opacity       : 1;
+
   position: relative;
   display: flex;
   align-items: center;
 
-  label {
-    margin-right: var(--fs-spacing-1);
-    color: var(--fs-color-text-light);
-  }
-
-  [data-store-select] {
-    padding: var(--fs-spacing-1) var(--fs-spacing-5) var(--fs-spacing-1) var(--fs-spacing-2);
-    color: var(--fs-color-link);
-    background: transparent;
+  select {
+    padding: var(--fs-select-padding);
+    color: var(--fs-select-text-color);
+    background: var(--fs-select-bkg);
     border: 0;
-    border-radius: var(--fs-border-radius-default);
+    border-radius: var(--fs-select-border-radius);
     box-shadow: 0;
-    transition: box-shadow .2s ease, background-color .2s ease;
+    transition: var(--fs-select-transition-property) var(--fs-select-transition-timing) var(--fs-select-transition-function);
     appearance: none;
 
     @include focus-ring-visible;
 
-    &:focus { background-color: var(--fs-color-primary-bkg-light); }
+    &:focus { background-color: var(--fs-select-bkg-color-focus); }
 
-    &:hover:not(:disabled) { background-color: var(--fs-color-primary-bkg-light); }
+    &:hover:not(:disabled) { background-color: var(--fs-select-bkg-color-hover); }
 
     &:disabled {
-      color: var(--fs-color-disabled-text);
+      color: var(--fs-select-disabled-text-color);
       cursor: not-allowed;
-      opacity: 1;
-      + svg { display: none; }
+      opacity: var(--fs-select-disabled-text-opacity);
+      + [data-fs-select-icon] { display: none; }
     }
 
-    @include media("<notebook") { min-height: var(--fs-control-tap-size); }
+    @include media("<notebook") { min-height: var(--fs-select-min-height); }
 
-    @include media(">=notebook") { height: var(--fs-spacing-6); }
+    @include media(">=notebook") { height: var(--fs-select-height); }
   }
+}
 
-  svg {
-    position: absolute;
-    right: var(--fs-spacing-2);
-    color: var(--fs-color-link);
-    pointer-events: none;
-  }
+[data-fs-select-label] {
+  margin-right: var(--fs-select-label-margin-right);
+  color: var(--fs-select-label-color);
+}
+
+[data-fs-select-icon] {
+  position: absolute;
+  right: var(--fs-select-icon-position-right);
+  color: var(--fs-select-icon-color);
+  pointer-events: none;
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

Ported from `gatsby.store` repo: [feat: Adds new tokens to Link #19](https://github.com/vtex-sites/gatsby.store/pull/19)

This PR intends to add new tokens to the `Link` component using the [Theming Structure](https://github.com/vtex-sites/base.store/pull/407).

## How does it work?

This PR uses local variables to parameterize the `Link` properties, then connects these scoped tokens to the global ones.

### New global tokens:
None.

### New local tokens for `Link`:

#### Default properties:
| Local token | Default value/Global token linked |
| - | - | 
| `--fs-link-min-width` | `auto` |
| `--fs-link-min-height` | `var(--fs-link-min-width)` |
| `--fs-link-padding` | `var(--fs-spacing-2) var(--fs-spacing-0)` |
| `--fs-link-text-color` | `var(--fs-color-link)` |
| `--fs-link-text-line-height` | `1.5` |
| `--fs-link-text-decoration` | `none` |
| `--fs-link-text-decoration-hover` | `underline` |
| `--fs-link-visited-text-color` | `var(--fs-color-link-visited)` |
| `--fs-link-border-radius` | `var(--fs-border-radius-default)` |
| `--fs-link-box-shadow-transition` | `box-shadow .5s ease` |
|  |  |
| `--fs-link-inverse-text-color` | `var(--fs-color-link-inverse)` |
| `--fs-link-inverse-visited-text-color` | `var(--fs-link-inverse-text-color)` |

#### Display:
| Local token | Default value/Global token linked |
| - | - | 
| `--fs-link-display-text-line-height` | `1.5` |
| `--fs-link-display-text-color` | `var(--fs-color-text-display)` |
| `--fs-link-display-visited-text-color` | `var(--fs-link-display-text-color)` |

#### Inline
| Local token | Default value/Global token linked |
| - | - | 
| `--fs-link-inline-padding` | `0` |
| `--fs-link-inline-text-decoration` | `underline` |

#### Footer
| Local token | Default value/Global token linked |
| - | - | 
| `--fs-link-footer-font-size` | `var(--fs-text-size-1)` |
| `--fs-link-footer-text-color` | `var(--fs-color-info-text)` |
| `--fs-link-footer-padding` | `var(--fs-spacing-1) var(--fs-spacing-0)` |

## How to test it?

The `Link` component and its variants should look just as it was before these changes.

## Checklist

- [ ] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [ ] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 


- PR description
- [x] Updated the Storybook - *if applicable*.
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.