### PR TITLE
feat: Disable 3P scripts on Codesandbox

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,9 +5,7 @@ import ThirdPartyScripts from 'src/components/ThirdPartyScripts'
 function Document() {
   return (
     <Html>
-      <Head>
-        <ThirdPartyScripts />
-      </Head>
+      <Head>{!process.env.DISABLE_3P_SCRIPTS && <ThirdPartyScripts />}</Head>
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to avoid iframe errors on Codesandbox by disabling third-party scripts on it.

## How does it work?

It checks if the `DISABLE_3P_SCRIPTS`envvar exists and is `true`. If so, it doesn't render the `ThirdPartyScripts` component.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [ ] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [ ] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 


- PR description
- [ ] Updated the Storybook - *if applicable*.
- [ ] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [ ] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [ ] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.
- [ ] For documentation changes, ping @carolinamenezes or @Mariana-Caetano to review and update the changes.

