### PR TITLE
fix: storybook build - removes unused import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Addded
+
 - Uses new WebOps Incremental Static Builds ([#39](https://github.com/vtex-sites/nextjs.store/pull/39))
 - An initial integration of the search term & product suggestions ([#33](https://github.com/vtex-sites/nextjs.store/pull/33)).
 - `ImageGallery` to PDP ([#6](https://github.com/vtex-sites/nextjs.store/pull/6))
@@ -22,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- Fixes Storybook build removing unused imports ([#40](https://github.com/vtex-sites/nextjs.store/pull/40))
 
 ### Security
 

--- a/src/styles/global/storybook-components.scss
+++ b/src/styles/global/storybook-components.scss
@@ -22,7 +22,6 @@
 @import "src/components/sections/Breadcrumb/breadcrumb.scss";
 @import "src/components/sections/Incentives/incentives.scss";
 @import "src/components/sections/ProductDetails/product-details.scss";
-@import "src/components/sections/ProductGallery/product-gallery.scss";
 @import "src/components/sections/ProductShelf/product-shelf.scss";
 @import "src/components/sections/ScrollToTopButton/scroll-to-top-button.scss";
 @import "src/components/sections/Section/section.scss";


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR attempts to fix storybook build removing unused import.

![image](https://user-images.githubusercontent.com/3356699/168703230-f1b54c6e-f0ba-45a2-855e-8797608b5053.png)


## How does it work?

- Removes unused import.

## How to test it?

- The [nextjs-store-storybook preview](https://nextjs-store-storybook-git-fix-storybook-remov-622190-faststore.vercel.app/) link should work normally.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 

