### PR TITLE
Chore: Uses camel-case classes when using CSS Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Uses camelCase classes when using CSS Modules ([#42](https://github.com/vtex-sites/nextjs.store/pull/42))
 - `ImageGallery` now uses native scroll instead of `useSlider` ([#6](https://github.com/vtex-sites/nextjs.store/pull/6))
 
 ### Deprecated

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ const nextConfig = {
     defaultLocale: 'en-US',
   },
   webpack: (config) => {
+    // https://github.com/vercel/next.js/discussions/11267#discussioncomment-2479112
     // camel-case style names from css modules
     config.module.rules
       .find(({ oneOf }) => !!oneOf)

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,20 @@ const nextConfig = {
     locales: ['en-US'],
     defaultLocale: 'en-US',
   },
+  webpack: (config) => {
+    // camel-case style names from css modules
+    config.module.rules
+      .find(({ oneOf }) => !!oneOf)
+      .oneOf.filter(({ use }) => JSON.stringify(use)?.includes('css-loader'))
+      .reduce((acc, { use }) => acc.concat(use), [])
+      .forEach(({ options }) => {
+        if (options.modules) {
+          options.modules.exportLocalsConvention = 'camelCase'
+        }
+      })
+
+    return config
+  },
 }
 
 module.exports = nextConfig

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -17,9 +17,13 @@ interface ImageGalleryProps {
 function ImageGallery({ images }: ImageGalleryProps) {
   const [selectedImageIdx, setSelectedImageIdx] = useState(0)
   const currentImage = images[selectedImageIdx]
+  const hasSelector = images.length > 1
 
   return (
-    <section data-fs-image-gallery className={styles['fs-image-gallery']}>
+    <section
+      data-fs-image-gallery={!hasSelector ? 'without-selector' : ''}
+      className={styles.fsImageGallery}
+    >
       <ImageZoom>
         <Image
           src={currentImage.url}
@@ -30,7 +34,7 @@ function ImageGallery({ images }: ImageGalleryProps) {
           loading="eager"
         />
       </ImageZoom>
-      {images.length > 1 && (
+      {hasSelector && (
         <ImageGallerySelector
           images={images}
           currentImageIdx={selectedImageIdx}

--- a/src/components/ui/ImageGallery/ImageGallerySelector.tsx
+++ b/src/components/ui/ImageGallery/ImageGallerySelector.tsx
@@ -40,7 +40,7 @@ function ImageGallerySelector({ images, onSelect, currentImageIdx }: Props) {
   return (
     <section
       data-fs-image-gallery-selector
-      className={styles['fs-image-gallery-selector']}
+      className={styles.fsImageGallerySelector}
       aria-roledescription="carousel"
       aria-label="Product images"
     >

--- a/src/components/ui/ImageGallery/image-gallery.module.scss
+++ b/src/components/ui/ImageGallery/image-gallery.module.scss
@@ -8,26 +8,29 @@
   row-gap: var(--fs-spacing-2);
   width: calc(100% + (2 * var(--fs-grid-padding)));
 
-  @include media(">=notebook") {
-    display: grid;
-    grid-template-columns: repeat(8, 1fr);
-    column-gap: var(--fs-spacing-3);
-  }
-
-  > [data-store-image] {
-    @include media(">=tablet") {
-      grid-column: 2 / span 7;
-      border-radius: var(--fs-border-radius-default);
-    }
-  }
-
   @include media(">=tablet") {
     left: 0;
     grid-row: 1 / span 2;
     grid-column: span 7;
     width: 100%;
     margin-bottom: var(--fs-spacing-7);
+
+    > [data-store-image] {
+      grid-column: 2 / span 7;
+      border-radius: var(--fs-border-radius-default);
+    }
+
+    &[data-fs-image-gallery="without-selector"] {
+      > [data-store-image] {
+        grid-column: 1 / span 8;
+      }
+    }
   }
 
-  @include media(">=notebook") { grid-column: span 8; }
+  @include media(">=notebook") {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    grid-column: span 8;
+    column-gap: var(--fs-spacing-3);
+  }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds a configuration to the store that import classes as camelCase through CSS modules. This is being done because gatsby.store only import classes as camelCase and is not recommended do to in other way because it removes the tree-shaking from it.

## How does it work?

It adds a chunk of code to `next.config.js` which changes the objected imported with CSS Modules.

## How to test it?

Open the preview and navigate to any product. The gallery should work for mobile and desktop

## References
https://github.com/vercel/next.js/discussions/11267
https://www.gatsbyjs.com/docs/how-to/styling/css-modules/
https://www.gatsbyjs.com/docs/how-to/styling/css-modules/

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 


- PR description
- [x] Updated the Storybook - *if applicable*.
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.
- [x] For documentation changes, ping @carolinamenezes or @Mariana-Caetano to review and update the changes.

