### PR TITLE
Fix: `InputText` story

### DIFF
--- a/src/components/ui/InputText/InputText.stories.tsx
+++ b/src/components/ui/InputText/InputText.stories.tsx
@@ -1,7 +1,7 @@
 import type { InputTextProps } from '.'
 import InputText from '.'
 
-export default {
+const story = {
   component: InputText,
   title: 'Atoms/InputText',
   argTypes: {
@@ -56,3 +56,5 @@ Disabled.args = {
   errorMessage: 'Please, add a valid email',
   disabled: true,
 }
+
+export default story


### PR DESCRIPTION
## What's the purpose of this pull request?
Removes `yarn build` warning
```
./src/components/ui/InputText/InputText.stories.tsx
4:1  Warning: Assign object to a variable before exporting as module default  import/no-anonymous-default-export
```
