### PR TITLE
Improve LCP by setting a higher fetch priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- LCP images to be fetched with a higher priority and improve the score ([#49](https://github.com/vtex-sites/nextjs.store/pull/49)).
 - Uses `ProductCard` component from FSUI instead of `Card` ([#41](https://github.com/vtex-sites/nextjs.store/pull/41))
 - `EmptyState` component to be customized with a rounded `variant` prop (`default` | `rounded`) ([#11](https://github.com/vtex-sites/nextjs.store/pull/11)).
 - Uses camelCase classes when using CSS Modules ([#42](https://github.com/vtex-sites/nextjs.store/pull/42))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Addded
+### Added
 
 - Uses new WebOps Incremental Static Builds ([#39](https://github.com/vtex-sites/nextjs.store/pull/39))
 - An initial integration of the search term & product suggestions ([#33](https://github.com/vtex-sites/nextjs.store/pull/33)).

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -46,6 +46,7 @@ const Hero = ({
           <Image
             preload
             loading="eager"
+            fetchpriority="high"
             src={imageSrc}
             alt={imageAlt}
             width={360}

--- a/src/components/ui/Image/Image.tsx
+++ b/src/components/ui/Image/Image.tsx
@@ -9,6 +9,7 @@ import type { ImageOptions } from './useImage'
 declare module 'react' {
   interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
     imageSizes?: string
+    fetchpriority?: string
   }
 }
 
@@ -17,7 +18,7 @@ interface Props extends ImageOptions {
 }
 
 // TODO: Replace this component by next/image
-function Image({ preload = false, ...otherProps }: Props) {
+function Image({ preload = false, fetchpriority, ...otherProps }: Props) {
   const imgProps = useImage(otherProps)
   const { src, sizes = '100vw', srcSet } = imgProps
 
@@ -31,11 +32,17 @@ function Image({ preload = false, ...otherProps }: Props) {
             href={src}
             imageSrcSet={srcSet}
             imageSizes={sizes}
+            fetchpriority={fetchpriority}
           />
         </Head>
       )}
       {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img data-store-image {...imgProps} alt={imgProps.alt} />
+      <img
+        data-store-image
+        {...imgProps}
+        alt={imgProps.alt}
+        fetchpriority={fetchpriority}
+      />
     </>
   )
 }

--- a/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -32,6 +32,7 @@ function ImageGallery({ images }: ImageGalleryProps) {
           width={804}
           height={804 * (3 / 4)}
           loading="eager"
+          fetchpriority="high"
         />
       </ImageZoom>
       {hasSelector && (


### PR DESCRIPTION
## What's the purpose of this pull request?

Try to improve the page LCP by boosting the priority for the main image.

## How does it work?

By setting `fetchpriority` to `high` we can hint the browser to give a higher priority to our LCP images.

## How to test it?

Use `psi-test` to compare before and after.

### Home

Page result - https://sfj-7de89f9--nextjs.preview.vtex.app/
| Metric | Mean | Standard deviation | Confidence Interval (95%) |
|--------|--------|--------|--------|
| Largest Contentful Paint (LCP) | 2221.49 | 152192.99 | [-64480.03, 68923.01] |
| Performance score | 0.839 | 0.000979 | [0.838571, 0.839429] |

Page result - https://sfj-f5d2958--nextjs.preview.vtex.app/
| Metric | Mean | Standard deviation | Confidence Interval (95%) |
|--------|--------|--------|--------|
| Largest Contentful Paint (LCP) | 1475.76 | 42521.48 | [-17160.10, 20111.61] |
| Performance score | 0.879 | 0.000619 | [0.878729, 0.879271] |

### PLP

Page result - https://sfj-7de89f9--nextjs.preview.vtex.app/office
| Metric | Mean | Standard deviation | Confidence Interval (95%) |
|--------|--------|--------|--------|
| Largest Contentful Paint (LCP) | 1681.58 | 120980.33 | [-51340.39, 54703.55] |
| Performance score | 0.899 | 0.000625 | [0.899226, 0.899774] |

Page result - https://sfj-f5d2958--nextjs.preview.vtex.app/office
| Metric | Mean | Standard deviation | Confidence Interval (95%) |
|--------|--------|--------|--------|
| Largest Contentful Paint (LCP) | 1422.32 | 55090.06 | [-22721.96, 25566.61] |
| Performance score | 0.903 | 0.000169 | [0.902426, 0.902574] |

### PDP

Page result - https://sfj-7de89f9--nextjs.preview.vtex.app/apple-magic-mouse-99988212/p
| Metric | Mean | Standard deviation | Confidence Interval (95%) |
|--------|--------|--------|--------|
| Largest Contentful Paint (LCP) | 2855.38 | 65371.98 | [-25795.15, 31505.92] |
| Performance score | 0.736 | 0.005824 | [0.733448, 0.738552] |

Page result - https://sfj-f5d2958--nextjs.preview.vtex.app/apple-magic-mouse-99988212/p
| Metric | Mean | Standard deviation | Confidence Interval (95%) |
|--------|--------|--------|--------|
| Largest Contentful Paint (LCP) | 2294.23 | 84993.06 | [-34955.62, 39544.08] |
| Performance score | 0.842 | 0.003156 | [0.840617, 0.843383] |

## References

- [[web.dev] Optimizing resource loading with Priority Hints](https://web.dev/priority-hints/)
- [[web.dev] Optimize Largest Contentful Paint](https://web.dev/optimize-lcp/)