### PR TITLE
chore: Removes `default` nomenclature from global tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- The `default` nomenclature from global tokens ([#51](https://github.com/vtex-sites/nextjs.store/pull/51))
+
 ### Fixed
 
 - A missing gap between the Sign In link and Cart button on desktop ([#11](https://github.com/vtex-sites/nextjs.store/pull/11)).

--- a/README.md
+++ b/README.md
@@ -370,8 +370,8 @@ We also listed a couple of customizable tokens so you can easily change your bod
 If you feel the need to edit some of the color decisions, you can enter `tokens.scss` and update the semantical tokens. E.g.:
 
 ```scss
---fs-border-color-default: var(--fs-color-neutral-4); // Current
---fs-border-color-default: var(--fs-color-neutral-5); // Updated
+--fs-border-color: var(--fs-color-neutral-4); // Current
+--fs-border-color: var(--fs-color-neutral-5); // Updated
 ```
 
 #### <b>Typography</b>

--- a/src/components/cart/CartItem/cart-item.scss
+++ b/src/components/cart/CartItem/cart-item.scss
@@ -3,8 +3,8 @@
 .cart-item {
   padding: var(--fs-spacing-3);
   background-color: var(--fs-color-neutral-0);
-  border: var(--fs-border-width-default) solid var(--fs-border-color-light);
-  border-radius: var(--fs-border-radius-default);
+  border: var(--fs-border-width) solid var(--fs-border-color-light);
+  border-radius: var(--fs-border-radius);
 
   [data-card-content] {
     display: grid;
@@ -16,7 +16,7 @@
   [data-gatsby-image-wrapper] {
     flex-shrink: 0;
     margin-bottom: auto;
-    border-radius: var(--fs-border-radius-default);
+    border-radius: var(--fs-border-radius);
   }
 
   [data-cart-item-summary] {

--- a/src/components/common/Footer/footer.scss
+++ b/src/components/common/Footer/footer.scss
@@ -94,7 +94,7 @@
     }
 
     svg {
-      border: var(--fs-border-width-default) solid var(--fs-color-neutral-3);
+      border: var(--fs-border-width) solid var(--fs-color-neutral-3);
       border-radius: var(--fs-border-radius-small);
     }
 

--- a/src/components/common/Navbar/navbar.scss
+++ b/src/components/common/Navbar/navbar.scss
@@ -2,7 +2,7 @@
 
 .navbar {
   padding: 0;
-  border-bottom: var(--fs-border-width-default) solid var(--fs-color-neutral-2);
+  border-bottom: var(--fs-border-width) solid var(--fs-color-neutral-2);
   box-shadow: 0 var(--fs-spacing-0) var(--fs-spacing-3) rgb(0 0 0 / 5%);
 
   [data-store-search-input-wrapper] {
@@ -205,7 +205,7 @@
   }
 
   @include media("<notebook") {
-    border-top: var(--fs-border-width-default) solid var(--fs-color-neutral-2);
-    border-bottom: var(--fs-border-width-default) solid var(--fs-color-neutral-2);
+    border-top: var(--fs-border-width) solid var(--fs-color-neutral-2);
+    border-bottom: var(--fs-border-width) solid var(--fs-color-neutral-2);
   }
 }

--- a/src/components/common/SearchInput/search-input.scss
+++ b/src/components/common/SearchInput/search-input.scss
@@ -11,13 +11,13 @@
   [data-store-input] {
     width: 100%;
     padding: var(--fs-spacing-1) var(--fs-spacing-7) var(--fs-spacing-1) var(--fs-spacing-2);
-    border: var(--fs-border-width-default) solid var(--fs-border-color-default);
-    border-radius: var(--fs-border-radius-default);
+    border: var(--fs-border-width) solid var(--fs-border-color);
+    border-radius: var(--fs-border-radius);
     transition: box-shadow .2s ease, border .2s ease;
 
     &:hover {
-      border-color: var(--fs-border-color-default-active);
-      box-shadow: 0 0 0 var(--fs-border-width-default) var(--fs-border-color-default-active);
+      border-color: var(--fs-border-color-active);
+      box-shadow: 0 0 0 var(--fs-border-width) var(--fs-border-color-active);
     }
 
     @include input-focus-ring;
@@ -69,7 +69,7 @@
 
 [data-store-search-input-dropdown-wrapper] {
   --navbar-header-padding-bottom: var(--fs-spacing-2);
-  --navbar-bottom-border: var(--fs-border-width-default);
+  --navbar-bottom-border: var(--fs-border-width);
   --collapse-search-bar-width: var(--fs-control-tap-size);
   /* stylelint-disable scss/operator-no-newline-after */
   --top:
@@ -100,9 +100,9 @@
     left: 0;
     width: 100%;
     overflow: hidden;
-    border: var(--fs-border-width-default) solid var(--fs-border-color-default);
+    border: var(--fs-border-width) solid var(--fs-border-color);
     border-top: none;
-    border-radius: 0 0 var(--fs-border-radius-default) var(--fs-border-radius-default);
+    border-radius: 0 0 var(--fs-border-radius) var(--fs-border-radius);
     box-shadow: var(--fs-shadow);
   }
 }

--- a/src/components/product/ProductCard/product-card.scss
+++ b/src/components/product/ProductCard/product-card.scss
@@ -16,11 +16,11 @@
   --fs-product-card-bkg-color-hover          : var(--fs-product-card-bkg-color);
   --fs-product-card-bkg-color-focus          : var(--fs-product-card-bkg-color-hover);
 
-  --fs-product-card-img-radius               : var(--fs-border-radius-default);
+  --fs-product-card-img-radius               : var(--fs-border-radius);
   --fs-product-card-content-padding          : var(--fs-spacing-2) 0 0 0;
 
-  --fs-product-card-border-radius            : var(--fs-border-radius-default);
-  --fs-product-card-border-width             : var(--fs-border-width-default);
+  --fs-product-card-border-radius            : var(--fs-border-radius);
+  --fs-product-card-border-width             : var(--fs-border-width);
 
   --fs-product-card-border-color             : var(--fs-border-color-light);
   --fs-product-card-border-color-hover       : var(--fs-border-color-light-hover);

--- a/src/components/regionalization/RegionalizationButton/regionalization-button.scss
+++ b/src/components/regionalization/RegionalizationButton/regionalization-button.scss
@@ -3,7 +3,7 @@
 [data-fs-regionalization-button] {
   padding-right: var(--fs-spacing-1);
   margin-left: calc(-1 * var(--fs-spacing-2));
-  border-right: var(--fs-border-width-default) solid var(--fs-border-color-light);
+  border-right: var(--fs-border-width) solid var(--fs-border-color-light);
 
   [data-fs-button][data-fs-button-variant="tertiary"] {
     color: var(--fs-color-text-display);

--- a/src/components/search/Filter/filter.scss
+++ b/src/components/search/Filter/filter.scss
@@ -23,7 +23,7 @@
 
     @include media(">=notebook") {
       border: 1px solid var(--fs-border-color-light);
-      border-radius: var(--fs-border-radius-default);
+      border-radius: var(--fs-border-radius);
     }
   }
 

--- a/src/components/search/SuggestionProductCard/suggestion-product-card.module.scss
+++ b/src/components/search/SuggestionProductCard/suggestion-product-card.module.scss
@@ -16,7 +16,7 @@
 
   [data-gatsby-image-wrapper] {
     flex-shrink: 0;
-    border-radius: var(--fs-border-radius-default);
+    border-radius: var(--fs-border-radius);
   }
 
   [data-fs-suggestion-product-card-summary] {

--- a/src/components/search/Suggestions/suggestions.module.scss
+++ b/src/components/search/Suggestions/suggestions.module.scss
@@ -39,7 +39,7 @@
     background-color: var(--fs-color-neutral-0);
 
     &:not(:last-child) {
-      border-bottom: var(--fs-border-width-default) solid var(--fs-border-color-light);
+      border-bottom: var(--fs-border-width) solid var(--fs-border-color-light);
     }
   }
 

--- a/src/components/sections/ProductDetails/product-details.scss
+++ b/src/components/sections/ProductDetails/product-details.scss
@@ -34,7 +34,7 @@
     grid-row: 1;
     grid-column: 8 / span 5;
     border: 1px solid var(--fs-border-color-light);
-    border-radius: var(--fs-border-radius-default) var(--fs-border-radius-default) 0 0;
+    border-radius: var(--fs-border-radius) var(--fs-border-radius) 0 0;
   }
 
   @include media(">=notebook") { grid-column: 9 / span 4; }
@@ -65,7 +65,7 @@
     padding: var(--fs-spacing-5);
     border: 1px solid var(--fs-border-color-light);
     border-top: 0;
-    border-radius: 0 0 var(--fs-border-radius-default) var(--fs-border-radius-default);
+    border-radius: 0 0 var(--fs-border-radius) var(--fs-border-radius);
   }
 
   @include media(">=notebook") { grid-column: 9 / span 4; }

--- a/src/components/sections/Section/section.scss
+++ b/src/components/sections/Section/section.scss
@@ -12,7 +12,7 @@
 
 .section__divisor {
   padding-top: var(--fs-spacing-5);
-  border-top: var(--fs-border-width-default) solid var(--fs-border-color-light);
+  border-top: var(--fs-border-width) solid var(--fs-border-color-light);
 
   @include media(">=notebook") { padding-top: var(--fs-spacing-9); }
 }

--- a/src/components/skeletons/FilterSkeleton/filter-skeleton.scss
+++ b/src/components/skeletons/FilterSkeleton/filter-skeleton.scss
@@ -11,8 +11,8 @@
     flex-direction: column;
     padding: var(--fs-spacing-1) var(--fs-spacing-1) var(--fs-spacing-0);
     overflow: hidden;
-    border: var(--fs-border-width-default) solid var(--fs-border-color-light);
-    border-radius: var(--fs-border-radius-default);
+    border: var(--fs-border-width) solid var(--fs-border-color-light);
+    border-radius: var(--fs-border-radius);
 
     [data-element-variant="text"] {
       min-width: 100%;

--- a/src/components/skeletons/ProductCardSkeleton/product-card-skeleton.scss
+++ b/src/components/skeletons/ProductCardSkeleton/product-card-skeleton.scss
@@ -8,8 +8,8 @@
   height: 100%;
   padding: var(--fs-spacing-1) var(--fs-spacing-1) var(--fs-spacing-2);
   overflow: hidden;
-  border: var(--fs-border-width-default) solid transparent;
-  border-radius: var(--fs-border-radius-default);
+  border: var(--fs-border-width) solid transparent;
+  border-radius: var(--fs-border-radius);
 
   @include media(">=notebook") { min-width: 12rem; }
 
@@ -17,7 +17,7 @@
     border: none;
 
     @include media(">=notebook") {
-      border: var(--fs-border-width-default) solid var(--fs-border-color-light);
+      border: var(--fs-border-width) solid var(--fs-border-color-light);
     }
   }
 

--- a/src/components/skeletons/ProductTilesSkeleton/ProductTileSkeleton/product-tile-skeleton.scss
+++ b/src/components/skeletons/ProductTilesSkeleton/ProductTileSkeleton/product-tile-skeleton.scss
@@ -29,7 +29,7 @@
   [data-product-tile-skeleton-image] {
     height: 60%;
     min-height: 60%;
-    border-radius: var(--fs-border-radius-default) var(--fs-border-radius-default) 0 0;
+    border-radius: var(--fs-border-radius) var(--fs-border-radius) 0 0;
 
     @include media(">=tablet") {
       height: 70%;
@@ -71,8 +71,8 @@
     align-items: flex-start;
     height: 40%;
     padding: var(--fs-spacing-3);
-    border-bottom-right-radius: var(--fs-border-radius-default);
-    border-bottom-left-radius: var(--fs-border-radius-default);
+    border-bottom-right-radius: var(--fs-border-radius);
+    border-bottom-left-radius: var(--fs-border-radius);
 
     @include media(">=tablet") {
       flex-flow: row wrap;

--- a/src/components/skeletons/SkeletonElement/skeleton-element.scss
+++ b/src/components/skeletons/SkeletonElement/skeleton-element.scss
@@ -7,7 +7,7 @@
   [data-skeleton-element-content] {
     overflow: hidden;
     background: var(--fs-color-disabled-bkg);
-    border-radius: var(--fs-border-radius-default);
+    border-radius: var(--fs-border-radius);
 
     &[data-element-variant="text"] {
       width: 100%;
@@ -18,11 +18,11 @@
       column-gap: var(--fs-spacing-2);
       width: var(--fs-spacing-13);
       min-height: var(--fs-spacing-5);
-      border-radius: var(--fs-border-radius-default);
+      border-radius: var(--fs-border-radius);
     }
 
     &[data-element-variant="image"] {
-      border-radius: var(--fs-border-radius-default);
+      border-radius: var(--fs-border-radius);
     }
 
     &[data-element-variant="badge"] {

--- a/src/components/ui/Badge/badge.scss
+++ b/src/components/ui/Badge/badge.scss
@@ -7,7 +7,7 @@
   --fs-badge-padding                      : var(--fs-spacing-0) var(--fs-spacing-2);
 
   --fs-badge-border-radius                : var(--fs-border-radius-pill);
-  --fs-badge-border-width                 : var(--fs-border-width-default);
+  --fs-badge-border-width                 : var(--fs-border-width);
   --fs-badge-border-color                 : transparent;
 
   --fs-badge-bkg-color                    : var(--fs-color-neutral-bkg);

--- a/src/components/ui/Breadcrumb/breadcrumb.scss
+++ b/src/components/ui/Breadcrumb/breadcrumb.scss
@@ -67,7 +67,7 @@
     [data-breadcrumb-divider] {
       height: var(--fs-spacing-3);
       margin: var(--fs-spacing-1);
-      border-left: var(--fs-border-width-default) solid var(--fs-border-color-light);
+      border-left: var(--fs-border-width) solid var(--fs-border-color-light);
     }
 
     [data-store-link] {
@@ -116,7 +116,7 @@
   margin-top: var(--fs-spacing-0);
   overflow: hidden;
   background: var(--fs-color-tertiary-bkg);
-  border-radius: var(--fs-border-radius-default);
+  border-radius: var(--fs-border-radius);
   box-shadow: var(--fs-shadow);
 
   [data-store-dropdown-menu-item] {

--- a/src/components/ui/Button/button.scss
+++ b/src/components/ui/Button/button.scss
@@ -13,7 +13,7 @@
   --fs-button-shadow                               : none;
   --fs-button-shadow-hover                         : none;
 
-  --fs-button-border-radius                        : var(--fs-border-radius-default);
+  --fs-button-border-radius                        : var(--fs-border-radius);
   --fs-button-border-width                         : var(--fs-border-width-thick);
   --fs-button-border-color                         : transparent;
 

--- a/src/components/ui/Checkbox/checkbox.scss
+++ b/src/components/ui/Checkbox/checkbox.scss
@@ -8,8 +8,8 @@
   width: rem(20px);
   height: rem(20px);
   cursor: pointer;
-  border: var(--fs-border-width-default) solid var(--fs-border-color-default);
-  border-radius: var(--fs-border-radius-default);
+  border: var(--fs-border-width) solid var(--fs-border-color);
+  border-radius: var(--fs-border-radius);
   outline: none;
   transition: border .2s ease, background-color .2s ease, box-shadow .2s ease;
   appearance: none;
@@ -25,7 +25,7 @@
     border: var(--fs-border-width-thick) solid var(--fs-color-neutral-0);
     border-top: 0;
     border-left: 0;
-    border-radius: var(--fs-border-width-default);
+    border-radius: var(--fs-border-width);
     opacity: 0;
     transform: rotate(45deg);
   }
@@ -33,12 +33,12 @@
   &:hover {
     background-color: var(--fs-color-primary-bkg-light);
     border-color: var(--fs-color-text);
-    box-shadow: 0 0 0 var(--fs-border-width-default) var(--fs-border-color-default-active);
+    box-shadow: 0 0 0 var(--fs-border-width) var(--fs-border-color-active);
   }
 
   &:checked {
     background-color: var(--fs-color-primary-bkg);
-    border-color: var(--fs-border-color-default-active);
+    border-color: var(--fs-border-color-active);
     border-width: 0;
 
     &::before {
@@ -53,7 +53,7 @@
 
   &[data-store-checkbox-partial="true"] {
     background-color: var(--fs-color-neutral-0);
-    border: var(--fs-border-width-default) solid var(--fs-color-primary-bkg);
+    border: var(--fs-border-width) solid var(--fs-color-primary-bkg);
 
     &::before {
       position: absolute;
@@ -63,7 +63,7 @@
       content: "";
       border-width: 0;
       border-bottom: var(--fs-border-width-thick) solid var(--fs-color-primary-bkg);
-      border-radius: var(--fs-border-width-default);
+      border-radius: var(--fs-border-width);
       opacity: 1;
       transform: rotate(0deg);
     }
@@ -82,18 +82,18 @@
   &:disabled {
     cursor: not-allowed;
     background-color: var(--fs-color-disabled-bkg);
-    border: var(--fs-border-width-default) solid var(--fs-border-color-default-disabled);
+    border: var(--fs-border-width) solid var(--fs-border-color-disabled);
 
     &::before {
-      border-color: var(--fs-border-color-default-disabled);
+      border-color: var(--fs-border-color-disabled);
     }
 
     &:hover {
       background-color: var(--fs-color-disabled-bkg);
-      border: var(--fs-border-width-default) solid var(--fs-border-color-default-disabled);
+      border: var(--fs-border-width) solid var(--fs-border-color-disabled);
 
       &::before {
-        border-color: var(--fs-border-color-default-disabled);
+        border-color: var(--fs-border-color-disabled);
       }
     }
 

--- a/src/components/ui/EmptyState/empty-state.scss
+++ b/src/components/ui/EmptyState/empty-state.scss
@@ -35,5 +35,5 @@
 }
 
 [data-fs-empty-state-variant="rounded"] {
-  border-radius: var(--fs-border-radius-default);
+  border-radius: var(--fs-border-radius);
 }

--- a/src/components/ui/ImageGallery/image-gallery-selector.module.scss
+++ b/src/components/ui/ImageGallery/image-gallery-selector.module.scss
@@ -18,7 +18,7 @@
       display: flex;
       height: fit-content;
       padding: var(--fs-spacing-1);
-      background-color: var(--fs-control-bkg-default);
+      background-color: var(--fs-control-bkg);
       border-radius: var(--fs-border-radius-circle);
       box-shadow: var(--fs-shadow);
     }
@@ -73,21 +73,21 @@
       overflow: hidden;
       background-color: transparent;
       border: var(--fs-border-width-thick) solid transparent;
-      border-radius: var(--fs-border-radius-default);
+      border-radius: var(--fs-border-radius);
       transition: all var(--fs-transition-timing) var(--fs-transition-function);
 
       &:hover:not([data-thumbnail-button="selected"]) {
-        border-color: var(--fs-border-color-default-active);
+        border-color: var(--fs-border-color-active);
       }
 
       &[data-thumbnail-button="selected"] {
-        border-color: var(--fs-border-color-default-active);
+        border-color: var(--fs-border-color-active);
         box-shadow: 0 0 0 var(--fs-border-width-thickest) var(--fs-color-focus-ring-outline);
       }
 
       [data-store-image] {
         border: var(--fs-border-width-thick) solid var(--fs-color-body-bkg);
-        border-radius: var(--fs-border-radius-default);
+        border-radius: var(--fs-border-radius);
       }
 
       @include focus-ring-visible;

--- a/src/components/ui/ImageGallery/image-gallery.module.scss
+++ b/src/components/ui/ImageGallery/image-gallery.module.scss
@@ -17,7 +17,7 @@
 
     > [data-store-image] {
       grid-column: 2 / span 7;
-      border-radius: var(--fs-border-radius-default);
+      border-radius: var(--fs-border-radius);
     }
 
     &[data-fs-image-gallery="without-selector"] {

--- a/src/components/ui/InputText/input-text.scss
+++ b/src/components/ui/InputText/input-text.scss
@@ -11,12 +11,12 @@
   --fs-input-height                : var(--fs-control-tap-size);
 
   --fs-input-box-shadow            : none;
-  --fs-input-box-shadow-hover      : 0 0 0 var(--fs-border-width-default) var(--fs-border-color-default-active);
+  --fs-input-box-shadow-hover      : 0 0 0 var(--fs-border-width) var(--fs-border-color-active);
 
-  --fs-input-border-radius         : var(--fs-border-radius-default);
-  --fs-input-border-width          : var(--fs-border-width-default);
-  --fs-input-border-color          : var(--fs-border-color-default);
-  --fs-input-border-color-hover    : var(--fs-border-color-default-active);
+  --fs-input-border-radius         : var(--fs-border-radius);
+  --fs-input-border-width          : var(--fs-border-width);
+  --fs-input-border-color          : var(--fs-border-color);
+  --fs-input-border-color-hover    : var(--fs-border-color-active);
 
   --fs-input-text-color            : var(--fs-color-text);
   --fs-input-text-color-label      : var(--fs-color-text-light);
@@ -33,14 +33,14 @@
 
   // Error
   --fs-input-error-border-color    : var(--fs-color-danger-border);
-  --fs-input-error-box-shadow      : 0 0 0 var(--fs-border-width-default) var(--fs-input-error-border-color);
+  --fs-input-error-box-shadow      : 0 0 0 var(--fs-border-width) var(--fs-input-error-border-color);
   --fs-input-error-focus-ring      : var(--fs-color-focus-ring-danger);
 
   // Disabled
   --fs-input-disabled-bkg-color    : var(--fs-color-disabled-bkg);
   --fs-input-disabled-text-color   : var(--fs-color-disabled-text);
-  --fs-input-disabled-border-width : var(--fs-border-width-default);
-  --fs-input-disabled-border-color : var(--fs-border-color-default);
+  --fs-input-disabled-border-width : var(--fs-border-width);
+  --fs-input-disabled-border-color : var(--fs-border-color);
 
   // --------------------------------------------------------
   // Structural Styles

--- a/src/components/ui/Link/link.scss
+++ b/src/components/ui/Link/link.scss
@@ -1,7 +1,7 @@
 @import "src/styles/scaffold";
 
 a, [data-fs-link] {
-  border-radius: var(--fs-border-radius-default);
+  border-radius: var(--fs-border-radius);
   transition: box-shadow .5s ease;
 
   @include focus-ring-visible;

--- a/src/components/ui/QuantitySelector/quantity-selector.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.scss
@@ -10,7 +10,7 @@
   --fs-qty-selector-height                    : calc(var(--fs-control-tap-size) + (var(--fs-qty-selector-border-width) * 2));
 
   --fs-qty-selector-shadow                    : none;
-  --fs-qty-selector-shadow-hover              : 0 0 0 var(--fs-border-width-default) var(--fs-border-color-default-active);
+  --fs-qty-selector-shadow-hover              : 0 0 0 var(--fs-border-width) var(--fs-border-color-active);
 
   --fs-qty-selector-bkg-color                 : var(--fs-color-body-bkg);
   --fs-qty-selector-bkg-color-hover           : var(--fs-qty-selector-bkg-color);
@@ -20,13 +20,13 @@
   --fs-qty-selector-text-color-hover          : var(--fs-qty-selector-text-color);
 
   --fs-qty-selector-icon-color                : var(--fs-color-link);
-  --fs-qty-selector-icon-color-hover          : var(--fs-border-color-default-active);
+  --fs-qty-selector-icon-color-hover          : var(--fs-border-color-active);
 
-  --fs-qty-selector-border-radius             : var(--fs-border-radius-default);
-  --fs-qty-selector-border-width              : var(--fs-border-width-default);
-  --fs-qty-selector-border-width-hover        : var(--fs-border-width-default);
-  --fs-qty-selector-border-color              : var(--fs-border-color-default);
-  --fs-qty-selector-border-color-hover        : var(--fs-border-color-default-active);
+  --fs-qty-selector-border-radius             : var(--fs-border-radius);
+  --fs-qty-selector-border-width              : var(--fs-border-width);
+  --fs-qty-selector-border-width-hover        : var(--fs-border-width);
+  --fs-qty-selector-border-color              : var(--fs-border-color);
+  --fs-qty-selector-border-color-hover        : var(--fs-border-color-active);
 
   --fs-qty-selector-button-shadow             : none;
   --fs-qty-selector-button-shadow-hover       : none;

--- a/src/components/ui/Select/select.scss
+++ b/src/components/ui/Select/select.scss
@@ -15,7 +15,7 @@
     color: var(--fs-color-link);
     background: transparent;
     border: 0;
-    border-radius: var(--fs-border-radius-default);
+    border-radius: var(--fs-border-radius);
     box-shadow: 0;
     transition: box-shadow .2s ease, background-color .2s ease;
     appearance: none;

--- a/src/components/ui/SkuSelector/sku-selector.scss
+++ b/src/components/ui/SkuSelector/sku-selector.scss
@@ -5,7 +5,7 @@
     @supports (-webkit-appearance:none) {
       // Use `focus` instead of `focus-visible` due to Safari's lack of support
       &:focus + span {
-        border-color: var(--fs-border-color-default-active);
+        border-color: var(--fs-border-color-active);
         border-width: var(--fs-border-width-thick);
 
         @include focus-ring;
@@ -14,7 +14,7 @@
   }
 
   &:focus-visible + span {
-    border-color: var(--fs-border-color-default-active);
+    border-color: var(--fs-border-color-active);
     border-width: var(--fs-border-width-thick);
 
     @include focus-ring;
@@ -45,8 +45,8 @@
       justify-content: center;
       width: 100%;
       height: 100%;
-      border: var(--fs-border-width-default) solid var(--fs-color-neutral-7);
-      border-radius: var(--fs-border-radius-default);
+      border: var(--fs-border-width) solid var(--fs-color-neutral-7);
+      border-radius: var(--fs-border-radius);
       box-shadow: 0;
       transition: box-shadow .2s ease, background-color .2s ease;
     }
@@ -61,12 +61,12 @@
       @include sku-selector-focus-ring;
 
       &:hover:not(:disabled):not(:checked) + span {
-        border-color: var(--fs-border-color-default-active);
+        border-color: var(--fs-border-color-active);
         border-width: var(--fs-border-width-thick);
       }
 
       &:checked + span {
-        border-color: var(--fs-border-color-default-active);
+        border-color: var(--fs-border-color-active);
         border-width: var(--fs-border-width-thick);
         box-shadow: 0 0 0 var(--fs-border-width-thickest) var(--fs-color-focus-ring-outline);
       }
@@ -77,14 +77,14 @@
         + span {
           overflow: hidden;
           color: var(--fs-color-disabled-text);
-          border-color: var(--fs-border-color-default-disabled);
+          border-color: var(--fs-border-color-disabled);
 
           &::after {
             position: absolute;
-            width: var(--fs-border-width-default);
+            width: var(--fs-border-width);
             height: 160%;
             content: "";
-            background-color: var(--fs-border-color-default-disabled);
+            background-color: var(--fs-border-color-disabled);
             transform: rotate(45deg);
             transform-origin: center;
           }

--- a/src/components/ui/Tiles/tiles.scss
+++ b/src/components/ui/Tiles/tiles.scss
@@ -17,7 +17,7 @@
 [data-tile] {
   min-width: 9rem;
   height: 24rem;
-  border-radius: var(--fs-border-radius-default);
+  border-radius: var(--fs-border-radius);
 
   @include media(">=tablet") { height: 28rem; }
 }

--- a/src/styles/global/tokens.scss
+++ b/src/styles/global/tokens.scss
@@ -267,7 +267,7 @@ body {
   --fs-border-width-thickest           : 3px;
 
   // SHADOW
-  --fs-shadow                          : none;
+  --fs-shadow                          : 0 1px 4px rgb(0 0 0 / 10%), 0 6px 8px rgb(0 0 0 / 10%);
   --fs-shadow-darker                   : 0 0 10px rgb(0 0 0 / 20%);
-  --fs-shadow-hover                    : 0 1px 4px rgb(0 0 0 / 10%), 0 6px 8px rgb(0 0 0 / 10%);
+  --fs-shadow-hover                    : var(--fs-shadow);
 }

--- a/src/styles/global/tokens.scss
+++ b/src/styles/global/tokens.scss
@@ -228,7 +228,7 @@ body {
   }
 
   // STATES
-  --fs-control-bkg-default             : var(--fs-color-neutral-0);
+  --fs-control-bkg                     : var(--fs-color-neutral-0);
   --fs-control-bkg-hover               : var(--fs-control-tap-size);
   --fs-control-bkg-active              : var(--fs-control-tap-size);
   --fs-control-bkg-disabled            : var(--fs-color-disabled-bkg);
@@ -246,27 +246,28 @@ body {
   --fs-transition-function             : ease-in-out;
 
   // BORDERS
-  --fs-border-radius-circle            : 100%;
-  --fs-border-radius-pill              : 100px;
   --fs-border-radius-small             : .125rem;
-  --fs-border-radius-default           : .25rem;
+  --fs-border-radius                   : .25rem;
+  --fs-border-radius-medium            : .5rem;
+  --fs-border-radius-pill              : 100px;
+  --fs-border-radius-circle            : 100%;
 
-  --fs-border-color-default            : var(--fs-color-neutral-4);
-  --fs-border-color-default-hover      : var(--fs-color-main-2);
-  --fs-border-color-default-active     : var(--fs-color-main-2);
-  --fs-border-color-default-disabled   : var(--fs-color-neutral-6);
+  --fs-border-color                    : var(--fs-color-neutral-4);
+  --fs-border-color-hover              : var(--fs-color-main-3);
+  --fs-border-color-active             : var(--fs-color-main-2);
+  --fs-border-color-disabled           : var(--fs-color-neutral-6);
 
   --fs-border-color-light              : var(--fs-color-neutral-2);
   --fs-border-color-light-hover        : var(--fs-color-neutral-3);
   --fs-border-color-light-active       : var(--fs-color-neutral-3);
   --fs-border-color-light-disabled     : var(--fs-color-neutral-5);
 
-  --fs-border-width-default            : 1px;
+  --fs-border-width                    : 1px;
   --fs-border-width-thick              : 2px;
   --fs-border-width-thickest           : 3px;
 
   // SHADOW
-  --fs-shadow                          : 0 1px 4px rgb(0 0 0 / 10%), 0 6px 8px rgb(0 0 0 / 10%);
+  --fs-shadow                          : none;
   --fs-shadow-darker                   : 0 0 10px rgb(0 0 0 / 20%);
-  --fs-shadow-hover                    : var(--fs-shadow);
+  --fs-shadow-hover                    : 0 1px 4px rgb(0 0 0 / 10%), 0 6px 8px rgb(0 0 0 / 10%);
 }

--- a/src/styles/global/utilities.scss
+++ b/src/styles/global/utilities.scss
@@ -17,7 +17,7 @@ $base: 16px !default;
   @return #{$rem}rem;
 }
 
-@mixin input-focus-ring($outline: #{var(--fs-color-focus-ring)}, $border: #{var(--fs-border-color-default-active)}) {
+@mixin input-focus-ring($outline: #{var(--fs-color-focus-ring)}, $border: #{var(--fs-border-color-active)}) {
   @media not all and (min-resolution: .001dpcm) { // Target only Safari browsers
     @supports (-webkit-appearance:none) {         // Use `focus` instead of `focus-visible`
       &:hover:focus,                              // due to Safari's lack of support
@@ -27,7 +27,7 @@ $base: 16px !default;
         box-shadow:
           0 0 0 1px var(--fs-color-body-bkg),
           0 0 0 var(--fs-border-width-thickest) $outline,
-          inset 0 0 0 var(--fs-border-width-default) $border;
+          inset 0 0 0 var(--fs-border-width) $border;
       }
     }
   }
@@ -39,7 +39,7 @@ $base: 16px !default;
     box-shadow:
       0 0 0 1px var(--fs-color-body-bkg),
       0 0 0 var(--fs-border-width-thickest) $outline,
-      inset 0 0 0 var(--fs-border-width-default) $border;
+      inset 0 0 0 var(--fs-border-width) $border;
   }
 }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to remove the `default` nomenclature from global tokens. We did the same in `gatsby.store` [here](https://github.com/vtex-sites/gatsby.store/pull/28/commits/a9defe9175896ca75ad5a5aa03d6373eec7d100a).

## How to test it?

These changes will not impact any part of the code, only tokens' nomenclature was updated.

## Checklist

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should come first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 

- PR description
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.