### PR TITLE
fix: Fixes `fetchPriority` prop warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Warning related to `fetchPriority` prop not being recognized as `img` and `link`'s prop ([#54](https://github.com/vtex-sites/nextjs.store/pull/54))
 - Error on Storybook build when trying to import base CSS styles/mixins in CSS module files ([#53](https://github.com/vtex-sites/nextjs.store/pull/53))
 - A missing gap between the Sign In link and Cart button on desktop ([#11](https://github.com/vtex-sites/nextjs.store/pull/11)).
 - A bugged vertical gap with the `EmptyState` component inside the cart ([#11](https://github.com/vtex-sites/nextjs.store/pull/11)).

--- a/src/components/ui/Image/Image.tsx
+++ b/src/components/ui/Image/Image.tsx
@@ -9,12 +9,13 @@ import type { ImageOptions } from './useImage'
 declare module 'react' {
   interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
     imageSizes?: string
-    fetchPriority?: string
+    fetchpriority?: string
   }
 }
 
 interface Props extends ImageOptions {
   preload?: boolean
+  fetchPriority?: string
 }
 
 // TODO: Replace this component by next/image
@@ -33,7 +34,7 @@ const Image = forwardRef<HTMLImageElement, Props>(
               href={src}
               imageSrcSet={srcSet}
               imageSizes={sizes}
-              fetchPriority={fetchPriority}
+              fetchpriority={fetchPriority}
             />
           </Head>
         )}
@@ -43,7 +44,7 @@ const Image = forwardRef<HTMLImageElement, Props>(
           data-store-image
           {...imgProps}
           alt={imgProps.alt}
-          fetchPriority={fetchPriority}
+          fetchpriority={fetchPriority}
         />
       </>
     )


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the warning related to `fetchPriority` prop being used with _camelCase_ and not being recognized as a DOM element's prop (`link` and `img` elements, in this case).

<img width="1654" alt="Screen Shot 2022-05-23 at 14 47 33" src="https://user-images.githubusercontent.com/15722605/169884038-6f040e34-f9ea-42b0-baea-fce899f5502b.png">

## How to test it?

Build locally, open the homepage (`localhost:3000`) and check if the warning is not being displayed in the terminal anymore.

## Checklist

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 