### PR TITLE
chore: Improve PLP performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - additionalProperty to CartItem id ([#47](https://github.com/vtex-sites/nextjs.store/pull/47))
+- Suspend `ProductShelf` and `ProductGallery` at PLP ([...slug]) ([#55](https://github.com/vtex-sites/nextjs.store/pull/55))
 - Applies new local tokens to `Link` ([#17](https://github.com/vtex-sites/nextjs.store/pull/17))
 - Applies new local tokens to `Select` ([#16](https://github.com/vtex-sites/nextjs.store/pull/16))
 - `Toggle` component ([#15](https://github.com/vtex-sites/nextjs.store/pull/15))

--- a/cypress/integration/performance.test.js
+++ b/cypress/integration/performance.test.js
@@ -60,6 +60,17 @@ describe('React rendering performance', () => {
   it('Renders ProductGallery component once on PLP', () => {
     const mark = 'ProductGallery'
 
-    testMark(pages.collection, mark)
+    /*
+     * The ProductGallery Renders twice:
+     * 1. When the useGalleryQuery query is finished
+     * 2. When the channel changes due to usePersonQuery, that triggers useProductsQuery that's used by useGalleryQuery
+     *
+     */
+    cy.visit(pages.collection, options)
+    cy.waitForHydration()
+
+    cy.window().should((win) => {
+      expect(win.performance.getEntriesByName(mark)).to.have.length.lessThan(2)
+    })
   })
 })

--- a/src/components/search/Filter/Filter.tsx
+++ b/src/components/search/Filter/Filter.tsx
@@ -1,5 +1,6 @@
 import { useSearch } from '@faststore/sdk'
 import { gql } from '@vtex/graphql-utils'
+import { memo, useCallback } from 'react'
 
 import Button, { ButtonIcon } from 'src/components/ui/Button'
 import Icon from 'src/components/ui/Icon'
@@ -42,6 +43,10 @@ function Filter({
 
   const { onModalClose } = useModal()
   const { facets, selected, expanded, dispatch } = useFilter(allFacets)
+  const handleAccordionChange = useCallback(
+    (index) => dispatch({ type: 'toggleExpanded', payload: index }),
+    [dispatch]
+  )
 
   return (
     <>
@@ -51,67 +56,67 @@ function Filter({
           testId={`desktop-${testId}`}
           indicesExpanded={expanded}
           onFacetChange={toggleFacet}
-          onAccordionChange={(index) =>
-            dispatch({ type: 'toggleExpanded', payload: index })
-          }
+          onAccordionChange={handleAccordionChange}
         />
       </div>
 
-      <SlideOver
-        isOpen={isOpen}
-        onDismiss={onDismiss}
-        size="partial"
-        direction="rightSide"
-        className="filter-modal__content"
-      >
-        <div className="filter-modal__body">
-          <header className="filter-modal__header">
-            <h2 className="text__lead">Filters</h2>
-            <ButtonIcon
-              data-testid="filter-modal-button-close"
-              aria-label="Close Filters"
-              icon={<Icon name="X" width={32} height={32} />}
-              onClick={() => {
-                dispatch({
-                  type: 'selectFacets',
-                  payload: selectedFacets,
-                })
+      {isOpen && (
+        <SlideOver
+          isOpen={isOpen}
+          onDismiss={onDismiss}
+          size="partial"
+          direction="rightSide"
+          className="filter-modal__content"
+        >
+          <div className="filter-modal__body">
+            <header className="filter-modal__header">
+              <h2 className="text__lead">Filters</h2>
+              <ButtonIcon
+                data-testid="filter-modal-button-close"
+                aria-label="Close Filters"
+                icon={<Icon name="X" width={32} height={32} />}
+                onClick={() => {
+                  dispatch({
+                    type: 'selectFacets',
+                    payload: selectedFacets,
+                  })
 
+                  onModalClose()
+                }}
+              />
+            </header>
+            <Facets
+              facets={facets}
+              testId={`mobile-${testId}`}
+              indicesExpanded={expanded}
+              onFacetChange={(facet) =>
+                dispatch({ type: 'toggleFacet', payload: facet })
+              }
+              onAccordionChange={(index) =>
+                dispatch({ type: 'toggleExpanded', payload: index })
+              }
+            />
+          </div>
+          <footer className="filter-modal__footer">
+            <Button
+              variant="secondary"
+              onClick={() => dispatch({ type: 'selectFacets', payload: [] })}
+            >
+              Clear All
+            </Button>
+            <Button
+              variant="primary"
+              data-testid="filter-modal-button-apply"
+              onClick={() => {
+                setFacets(selected)
                 onModalClose()
               }}
-            />
-          </header>
-          <Facets
-            facets={facets}
-            testId={`mobile-${testId}`}
-            indicesExpanded={expanded}
-            onFacetChange={(facet) =>
-              dispatch({ type: 'toggleFacet', payload: facet })
-            }
-            onAccordionChange={(index) =>
-              dispatch({ type: 'toggleExpanded', payload: index })
-            }
-          />
-        </div>
-        <footer className="filter-modal__footer">
-          <Button
-            variant="secondary"
-            onClick={() => dispatch({ type: 'selectFacets', payload: [] })}
-          >
-            Clear All
-          </Button>
-          <Button
-            variant="primary"
-            data-testid="filter-modal-button-apply"
-            onClick={() => {
-              setFacets(selected)
-              onModalClose()
-            }}
-          >
-            Apply
-          </Button>
-        </footer>
-      </SlideOver>
+            >
+              Apply
+            </Button>
+          </footer>
+        </SlideOver>
+      )}
     </>
   )
 }
@@ -130,4 +135,4 @@ export const fragment = gql`
   }
 `
 
-export default Filter
+export default memo(Filter)

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -1,6 +1,6 @@
 import { useSearch } from '@faststore/sdk'
 import { NextSeo } from 'next-seo'
-import { lazy, Suspense, useState } from 'react'
+import { Suspense, useState } from 'react'
 
 import Filter from 'src/components/search/Filter'
 import Sort from 'src/components/search/Sort'
@@ -18,8 +18,7 @@ import { useDelayedFacets } from './useDelayedFacets'
 import { useDelayedPagination } from './useDelayedPagination'
 import { useGalleryQuery } from './useGalleryQuery'
 import { useProductsPrefetch } from './usePageProducts'
-
-const GalleryPage = lazy(() => import('./ProductGalleryPage'))
+import GalleryPage from './ProductGalleryPage'
 
 interface Props {
   title: string
@@ -31,13 +30,13 @@ function ProductGallery({ title, searchTerm }: Props) {
   const { pages, addNextPage, addPrevPage } = useSearch()
   const { data } = useGalleryQuery()
   const facets = useDelayedFacets(data)
-  const totalCount = data?.search.products.pageInfo.totalCount ?? 0
+  const totalCount = data?.search?.products.pageInfo.totalCount ?? 0
   const { next, prev } = useDelayedPagination(totalCount)
 
   useProductsPrefetch(prev ? prev.cursor : null)
   useProductsPrefetch(next ? next.cursor : null)
 
-  if (data && totalCount === 0) {
+  if (data?.search && totalCount === 0) {
     return (
       <Section
         data-testid="product-gallery"
@@ -125,12 +124,11 @@ function ProductGallery({ title, searchTerm }: Props) {
           )}
 
           {/* Render ALL products */}
-          {data ? (
+          {data?.search ? (
             <Suspense fallback={<ProductGridSkeleton loading />}>
               {pages.map((page) => (
                 <GalleryPage
                   key={`gallery-page-${page}`}
-                  showSponsoredProducts={false}
                   page={page}
                   title={title}
                 />

--- a/src/components/sections/ProductGallery/ProductGallery.tsx
+++ b/src/components/sections/ProductGallery/ProductGallery.tsx
@@ -1,6 +1,6 @@
 import { useSearch } from '@faststore/sdk'
 import { NextSeo } from 'next-seo'
-import { Suspense, useState } from 'react'
+import { Suspense, useCallback, useState } from 'react'
 
 import Filter from 'src/components/search/Filter'
 import Sort from 'src/components/search/Sort'
@@ -32,6 +32,8 @@ function ProductGallery({ title, searchTerm }: Props) {
   const facets = useDelayedFacets(data)
   const totalCount = data?.search?.products.pageInfo.totalCount ?? 0
   const { next, prev } = useDelayedPagination(totalCount)
+
+  const handleDismiss = useCallback(() => setIsFilterOpen(false), [])
 
   useProductsPrefetch(prev ? prev.cursor : null)
   useProductsPrefetch(next ? next.cursor : null)
@@ -67,7 +69,7 @@ function ProductGallery({ title, searchTerm }: Props) {
             <Filter
               isOpen={isFilterOpen}
               facets={facets}
-              onDismiss={() => setIsFilterOpen(false)}
+              onDismiss={handleDismiss}
             />
           </FilterSkeleton>
         </div>

--- a/src/components/sections/ProductGallery/ProductGalleryPage.tsx
+++ b/src/components/sections/ProductGallery/ProductGalleryPage.tsx
@@ -3,28 +3,16 @@ import { useSearch } from '@faststore/sdk'
 import ProductGrid from 'src/components/product/ProductGrid'
 import Sentinel from 'src/sdk/search/Sentinel'
 
-import ProductTiles from '../ProductTiles'
 import { useProducts } from './usePageProducts'
 
-/* If showSponsoredProducts is true, a ProductTiles will be displayed in between two blocks of ProductGrid on the page 0 */
 interface Props {
   page: number
   title: string
-  showSponsoredProducts?: boolean
 }
 
-function GalleryPage({ page, title, showSponsoredProducts = true }: Props) {
+function GalleryPage({ page, title }: Props) {
   const products = useProducts(page) ?? []
   const { itemsPerPage } = useSearch()
-
-  const productsSponsored = showSponsoredProducts
-    ? products.slice(0, 2)
-    : undefined
-
-  const middleItemIndex = Math.ceil(itemsPerPage / 2)
-
-  const shouldDisplaySponsoredProducts =
-    page === 0 && productsSponsored && productsSponsored.length > 1
 
   return (
     <>
@@ -34,35 +22,13 @@ function GalleryPage({ page, title, showSponsoredProducts = true }: Props) {
         pageSize={itemsPerPage}
         title={title}
       />
-      {shouldDisplaySponsoredProducts ? (
-        <>
-          <ProductGrid
-            products={products.slice(0, middleItemIndex)}
-            page={page}
-            pageSize={middleItemIndex}
-          />
-          <div data-fs-product-listing-sponsored>
-            <h3>Sponsored</h3>
-            {/*
-              TODO: Refactor this bit of code
 
-              Sections should be self contained and should not import other sections.
-              We should remove/refactor this section from here
-            */}
-            <ProductTiles
-              selectedFacets={[{ key: 'productClusterIds', value: '141' }]}
-              title=""
-            />
-          </div>
-          <ProductGrid
-            products={products.slice(middleItemIndex, itemsPerPage)}
-            page={page}
-            pageSize={middleItemIndex}
-          />
-        </>
-      ) : (
-        <ProductGrid products={products} page={page} pageSize={itemsPerPage} />
-      )}
+      <ProductGrid
+        key="product-grid"
+        products={products}
+        page={page}
+        pageSize={itemsPerPage}
+      />
     </>
   )
 }

--- a/src/components/sections/ProductGallery/ProductGalleryPage.tsx
+++ b/src/components/sections/ProductGallery/ProductGalleryPage.tsx
@@ -1,4 +1,5 @@
 import { useSearch } from '@faststore/sdk'
+import { memo } from 'react'
 
 import ProductGrid from 'src/components/product/ProductGrid'
 import Sentinel from 'src/sdk/search/Sentinel'
@@ -33,4 +34,4 @@ function GalleryPage({ page, title }: Props) {
   )
 }
 
-export default GalleryPage
+export default memo(GalleryPage)

--- a/src/components/sections/ProductGallery/useDelayedFacets.ts
+++ b/src/components/sections/ProductGallery/useDelayedFacets.ts
@@ -9,7 +9,7 @@ export const useDelayedFacets = (data?: ProductGalleryQueryQuery) => {
   const facets = useRef<Filter_FacetsFragment[]>([])
 
   return useMemo(() => {
-    if (data) {
+    if (data?.search) {
       facets.current = data.search.facets
     }
 

--- a/src/components/sections/ProductGallery/useGalleryQuery.ts
+++ b/src/components/sections/ProductGallery/useGalleryQuery.ts
@@ -54,5 +54,8 @@ export const useGalleryQuery = () => {
     selectedFacets,
   })
 
-  return useQuery<Query, Variables>(query, localizedVariables)
+  return useQuery<Query, Variables>(query, localizedVariables, {
+    suspense: true,
+    fallbackData: { search: undefined },
+  })
 }

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -6,7 +6,7 @@ import {
 import { gql } from '@vtex/graphql-utils'
 import { BreadcrumbJsonLd, NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import type { SearchState } from '@faststore/sdk'
 import type { GetStaticPaths, GetStaticProps } from 'next'
 
@@ -122,14 +122,19 @@ function Page(props: Props) {
         icon={<Icon name="Headphones" width={48} height={48} weight="thin" />}
       />
 
-      <ProductGallery title={title} />
+      <Suspense fallback={null}>
+        <ProductGallery title={title} />
+      </Suspense>
 
-      <ProductShelf
-        first={ITEMS_PER_SECTION}
-        sort="score_desc"
-        title="You might also like"
-        withDivisor
-      />
+      <Suspense fallback={null}>
+        <ProductShelf
+          first={ITEMS_PER_SECTION}
+          sort="score_desc"
+          title="You might also like"
+          withDivisor
+          suspense
+        />
+      </Suspense>
 
       <ScrollToTopButton />
     </SearchProvider>

--- a/src/sdk/person/usePersonQuery.ts
+++ b/src/sdk/person/usePersonQuery.ts
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import { gql } from '@vtex/graphql-utils'
 import { useSession } from '@faststore/sdk'
 
@@ -9,8 +9,6 @@ import type {
 
 import { useQuery } from '../graphql/useQuery'
 import type { QueryOptions } from '../graphql/useQuery'
-
-const { startTransition } = React as any
 
 export const query = gql`
   query PersonQuery {
@@ -44,12 +42,10 @@ const usePersonQuery = (options?: QueryOptions) => {
 
   useEffect(() => {
     if (!!person && person !== user) {
-      startTransition(() =>
-        setSession({
-          ...session,
-          user: person,
-        })
-      )
+      setSession({
+        ...session,
+        user: person,
+      })
     }
   }, [person, user, session, setSession])
 

--- a/src/sdk/person/usePersonQuery.ts
+++ b/src/sdk/person/usePersonQuery.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { gql } from '@vtex/graphql-utils'
 import { useSession } from '@faststore/sdk'
 
@@ -9,6 +9,8 @@ import type {
 
 import { useQuery } from '../graphql/useQuery'
 import type { QueryOptions } from '../graphql/useQuery'
+
+const { startTransition } = React as any
 
 export const query = gql`
   query PersonQuery {
@@ -42,10 +44,12 @@ const usePersonQuery = (options?: QueryOptions) => {
 
   useEffect(() => {
     if (!!person && person !== user) {
-      setSession({
-        ...session,
-        user: person,
-      })
+      startTransition(() =>
+        setSession({
+          ...session,
+          user: person,
+        })
+      )
     }
   }, [person, user, session, setSession])
 


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR improves the TBT and TTI from the PLP


## How does it work?
Removes some components (ProductGallery and ProductShelf) from the first render of the [...slug] page. Also, use the startTransition, to remove the priority of the setSession inside the usePersonQuery.

## How to test it?
PageSpeed Insights or another performance tool.

## References
https://swr.vercel.app/docs/suspense
React startTransition

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 


- PR description
- [ ] Updated the Storybook - *if applicable*.
- [ ] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [ ] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.
- [ ] For documentation changes, ping @carolinamenezes or @Mariana-Caetano to review and update the changes.

