### PR TITLE
fix: Fixes custom attributes for img and link tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Limit custom props only for `img` and `link` tags ([#60](https://github.com/vtex-sites/nextjs.store/pull/60))
 - Warning related to `fetchPriority` prop not being recognized as `img` and `link`'s prop ([#54](https://github.com/vtex-sites/nextjs.store/pull/54))
 - Error on Storybook build when trying to import base CSS styles/mixins in CSS module files ([#53](https://github.com/vtex-sites/nextjs.store/pull/53))
 - A missing gap between the Sign In link and Cart button on desktop ([#11](https://github.com/vtex-sites/nextjs.store/pull/11)).

--- a/src/components/ui/Image/Image.tsx
+++ b/src/components/ui/Image/Image.tsx
@@ -7,8 +7,12 @@ import type { ImageOptions } from './useImage'
 // React still don't have imageSizes declared on its types. Somehow,
 // it generated the right html
 declare module 'react' {
-  interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
-    imageSizes?: string
+  interface ImgHTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+    fetchpriority?: string
+  }
+
+  interface LinkHTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+    imagesizes?: string
     fetchpriority?: string
   }
 }
@@ -33,7 +37,7 @@ const Image = forwardRef<HTMLImageElement, Props>(
               rel="preload"
               href={src}
               imageSrcSet={srcSet}
-              imageSizes={sizes}
+              imagesizes={sizes}
               fetchpriority={fetchPriority}
             />
           </Head>


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR is derived from: https://github.com/vtex-sites/gatsby.store/pull/60.

This PR intends to fix global props being visible/possible for types/interfaces extended from a global interface.

In the `Image` component we declared some props for the React global interface, `HTMLAttributes`, and it affected other components. We could detect this by looking into Storybook args for any components:

![Screen Shot 2022-05-24 at 13 49 32](https://user-images.githubusercontent.com/15722605/170095783-56ff4a83-f145-4f5c-822c-8e0f0bac7c19.png)
![Screen Shot 2022-05-24 at 13 51 35](https://user-images.githubusercontent.com/15722605/170095792-3963ef40-d762-4a71-96e5-fc74edf7bb12.png)

## How does it work?

With these changes, we narrowed the custom attributes only to the specific HTML tags `img` and `link`.

## How to test it?

It can be tested by looking into the components' Storybook args and checking if any of the custom attributes (i.e, `fetchPriority`) are visible.

## Checklist

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#12](https://github.com/vtex-sites/gatsby.store/pull/12))* 

- PR description
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.