### PR TITLE
fix: Fixes <link /> attribute typo

### DIFF
--- a/src/components/ui/Image/Image.tsx
+++ b/src/components/ui/Image/Image.tsx
@@ -12,7 +12,7 @@ declare module 'react' {
   }
 
   interface LinkHTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
-    imagesizes?: string
+    imageSizes?: string
     fetchpriority?: string
   }
 }
@@ -37,7 +37,7 @@ const Image = forwardRef<HTMLImageElement, Props>(
               rel="preload"
               href={src}
               imageSrcSet={srcSet}
-              imagesizes={sizes}
+              imageSizes={sizes}
               fetchpriority={fetchPriority}
             />
           </Head>


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix a `link` attribute typo. (`imageSizes` instead `imagesizes`)

<img width="860" alt="Screen Shot 2022-05-25 at 09 21 04" src="https://user-images.githubusercontent.com/15722605/170260677-76df2e66-4554-4c8b-b854-f59d645d513a.png">

## How to test it?

Just try to build locally and go to the homepage, the terminal should not show the warning again.