### PR TITLE
chore: Uses CSS Modules at `QuantitySelector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Uses CSS Modules on `QuantitySelector` component [#76](https://github.com/vtex-sites/nextjs.store/pull/76)
 - Added base files (`Getting Started`, `Theming`, `Colors`, `Typography` and `Icons`) to Storybook ([#67](https://github.com/vtex-sites/nextjs.store/pull/67))
 - Updated tokens' naming scheme ([#67](https://github.com/vtex-sites/nextjs.store/pull/67))
 - `OutOfStock` component ([#72](https://github.com/vtex-sites/nextjs.store/pull/72))

--- a/src/components/ui/QuantitySelector/QuantitySelector.tsx
+++ b/src/components/ui/QuantitySelector/QuantitySelector.tsx
@@ -3,6 +3,8 @@ import { memo, useEffect, useState } from 'react'
 
 import Icon from 'src/components/ui/Icon'
 
+import styles from './quantity-selector.module.scss'
+
 interface QuantitySelectorProps {
   max?: number
   min?: number
@@ -60,6 +62,7 @@ export function QuantitySelector({
   return (
     <UIQuantitySelector
       data-fs-quantity-selector={disabled ? 'disabled' : 'true'}
+      className={styles.fsQuantitySelector}
       quantity={quantity}
       leftButtonProps={{
         onClick: decrease,

--- a/src/components/ui/QuantitySelector/quantity-selector.module.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.module.scss
@@ -1,6 +1,6 @@
 @import "src/styles/scaffold";
 
-[data-fs-quantity-selector] {
+.fs-quantity-selector {
   // --------------------------------------------------------
   // Design Tokens for Quantity Selector
   // --------------------------------------------------------
@@ -145,16 +145,16 @@
       box-shadow: var(--fs-qty-selector-shadow-hover);
     }
   }
-}
 
-// --------------------------------------------------------
-// Variants Styles
-// --------------------------------------------------------
+  // --------------------------------------------------------
+  // Variants Styles
+  // --------------------------------------------------------
 
-[data-fs-quantity-selector="disabled"] {
-  [data-quantity-selector-input] {
-    background-color: var(--fs-qty-selector-disabled-bkg-color);
-    border-color: var(--fs-qty-selector-disabled-border-color);
+  &[data-fs-quantity-selector="disabled"] {
+    [data-quantity-selector-input] {
+      background-color: var(--fs-qty-selector-disabled-bkg-color);
+      border-color: var(--fs-qty-selector-disabled-border-color);
+    }
+    [data-quantity-selector-button]:hover [data-store-icon] { background-color: transparent; }
   }
-  [data-quantity-selector-button]:hover [data-store-icon] { background-color: transparent; }
 }

--- a/src/styles/global/components.scss
+++ b/src/styles/global/components.scss
@@ -49,7 +49,6 @@
 @import "src/components/ui/InputText/input-text.scss";
 @import "src/components/ui/Price/price.scss";
 @import "src/components/ui/ProductTitle/product-title.scss";
-@import "src/components/ui/QuantitySelector/quantity-selector.scss";
 @import "src/components/ui/SlideOver/slide-over.scss";
 @import "src/components/ui/SROnly/sr-only.scss";
 @import "src/components/ui/Tiles/tiles.scss";

--- a/src/styles/global/storybook-components.scss
+++ b/src/styles/global/storybook-components.scss
@@ -46,7 +46,6 @@
 @import "src/components/ui/InputText/input-text.scss";
 @import "src/components/ui/Price/price.scss";
 @import "src/components/ui/ProductTitle/product-title.scss";
-@import "src/components/ui/QuantitySelector/quantity-selector.scss";
 @import "src/components/ui/SlideOver/slide-over.scss";
 @import "src/components/ui/SROnly/sr-only.scss";
 @import "src/components/ui/Tiles/tiles.scss";


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR uses CSS modules to import the QuantitySelector component.

## How to test it?

Check if the `QuantitySelector` works at the cart and at the PDP.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 


- PR description
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

