### PR TITLE
fix: Removes unused `-default` at css variables

### DIFF
--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -3,7 +3,7 @@
   margin-bottom: var(--fs-spacing-4);
   color: var(--fs-color-text-inverse);
   background-color: var(--fs-color-main-0);
-  border-radius: var(--fs-border-radius-default);
+  border-radius: var(--fs-border-radius);
 }
 
 .sbdocs-content > header h1 { margin-bottom: 0; }

--- a/src/components/ui/Toggle/Toggle.stories.mdx
+++ b/src/components/ui/Toggle/Toggle.stories.mdx
@@ -88,7 +88,7 @@ An input checkbox styled to look like a switch button.
       </td>
       <td>
         <div style={{ backgroundColor: 'var(--fs-color-main-3)' }} />
-        <code>var(--fs-control-bkg-default)</code>
+        <code>var(--fs-control-bkg)</code>
       </td>
     </tr>
     <tr>
@@ -129,8 +129,8 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-color</code>
       </td>
       <td>
-        <div style={{ backgroundColor: 'var(--fs-border-color-default)' }} />
-        <code>var(--fs-border-color-default)</code>
+        <div style={{ backgroundColor: 'var(--fs-border-color)' }} />
+        <code>var(--fs-border-color)</code>
       </td>
     </tr>
     <tr>
@@ -138,10 +138,8 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-color-hover</code>
       </td>
       <td>
-        <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-hover)' }}
-        />
-        <code>var(--fs-border-color-default-hover)</code>
+        <div style={{ backgroundColor: 'var(--fs-border-color-hover)' }} />
+        <code>var(--fs-border-color-hover)</code>
       </td>
     </tr>
     <tr>
@@ -149,7 +147,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-radius</code>
       </td>
       <td>
-        <code>var(--fs-border-radius-default)</code>
+        <code>var(--fs-border-radius)</code>
       </td>
     </tr>
     <tr>
@@ -157,7 +155,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-border-width</code>
       </td>
       <td>
-        <code>var(--fs-border-width-default)</code>
+        <code>var(--fs-border-width)</code>
       </td>
     </tr>
     <tr>
@@ -233,9 +231,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-knob-bkg-color-hover</code>
       </td>
       <td>
-        <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-hover)' }}
-        />
+        <div style={{ backgroundColor: 'var(--fs-border-color-hover)' }} />
         <code>var(--fs-toggle-border-color-hover)</code>
       </td>
     </tr>
@@ -261,9 +257,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-knob-border-color-hover</code>
       </td>
       <td>
-        <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-hover)' }}
-        />
+        <div style={{ backgroundColor: 'var(--fs-border-color-hover)' }} />
         <code>var(--fs-toggle-border-color-hover)</code>
       </td>
     </tr>
@@ -284,8 +278,8 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-knob-checked-bkg-color</code>
       </td>
       <td>
-        <div style={{ backgroundColor: 'var(--fs-control-bkg-default)' }} />
-        <code>var(--fs-control-bkg-default)</code>
+        <div style={{ backgroundColor: 'var(--fs-control-bkg)' }} />
+        <code>var(--fs-control-bkg)</code>
       </td>
     </tr>
     <tr>
@@ -293,7 +287,7 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-knob-checked-border-color</code>
       </td>
       <td>
-        <div style={{ backgroundColor: 'var(--fs-control-bkg-default)' }} />
+        <div style={{ backgroundColor: 'var(--fs-control-bkg)' }} />
         <code>var(--fs-toggle-knob-checked-bkg-color)</code>
       </td>
     </tr>
@@ -475,10 +469,8 @@ An input checkbox styled to look like a switch button.
         <code>fs-toggle-checked-border-color</code>
       </td>
       <td>
-        <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-active' }}
-        />
-        <code>var(--fs-border-color-default-active)</code>
+        <div style={{ backgroundColor: 'var(--fs-border-color-active' }} />
+        <code>var(--fs-border-color-active)</code>
       </td>
     </tr>
     <tr>
@@ -547,10 +539,8 @@ An input checkbox styled to look like a switch button.
         <code>--fs-toggle-disabled-border-color</code>
       </td>
       <td>
-        <div
-          style={{ backgroundColor: 'var(--fs-border-color-default-disabled)' }}
-        />
-        <code>var(--fs-border-color-default-disabled)</code>
+        <div style={{ backgroundColor: 'var(--fs-border-color-disabled)' }} />
+        <code>var(--fs-border-color-disabled)</code>
       </td>
     </tr>
   </tbody>

--- a/src/components/ui/Toggle/toggle.scss
+++ b/src/components/ui/Toggle/toggle.scss
@@ -8,16 +8,16 @@
   // Default properties
   --fs-toggle-height                           : calc(var(--fs-control-min-height) / 1.75);
 
-  --fs-toggle-bkg-color                        : var(--fs-control-bkg-default);
+  --fs-toggle-bkg-color                        : var(--fs-control-bkg);
   --fs-toggle-bkg-color-hover                  : var(--fs-color-primary-bkg-light);
 
   --fs-toggle-shadow                           : var(--fs-shadow);
   --fs-toggle-shadow-hover                     : var(--fs-shadow);
 
-  --fs-toggle-border-color                     : var(--fs-border-color-default);
-  --fs-toggle-border-color-hover               : var(--fs-border-color-default-hover);
-  --fs-toggle-border-radius                    : var(--fs-border-radius-default);
-  --fs-toggle-border-width                     : var(--fs-border-width-default);
+  --fs-toggle-border-color                     : var(--fs-border-color);
+  --fs-toggle-border-color-hover               : var(--fs-border-color-hover);
+  --fs-toggle-border-radius                    : var(--fs-border-radius);
+  --fs-toggle-border-width                     : var(--fs-border-width);
 
   --fs-toggle-transition-timing                : var(--fs-transition-timing);
   --fs-toggle-transition-property              : var(--fs-transition-property);
@@ -32,7 +32,7 @@
   --fs-toggle-knob-border-color-hover          : var(--fs-toggle-border-color-hover);
   --fs-toggle-knob-border-width                : var(--fs-toggle-border-width);
 
-  --fs-toggle-knob-checked-bkg-color           : var(--fs-control-bkg-default);
+  --fs-toggle-knob-checked-bkg-color           : var(--fs-control-bkg);
   --fs-toggle-knob-checked-border-color        : var(--fs-toggle-knob-checked-bkg-color);
 
   --fs-toggle-knob-disabled-bkg-color          : var(--fs-color-neutral-5);
@@ -47,12 +47,12 @@
   // Checked
   --fs-toggle-checked-bkg-color                : var(--fs-color-primary-bkg-active);
   --fs-toggle-checked-bkg-color-hover          : var(--fs-color-primary-bkg-hover);
-  --fs-toggle-checked-border-color             : var(--fs-border-color-default-active);
+  --fs-toggle-checked-border-color             : var(--fs-border-color-active);
   --fs-toggle-checked-border-color-hover       : var(--fs-toggle-checked-bkg-color-hover);
 
   // Disabled
   --fs-toggle-disabled-bkg-color               : var(--fs-color-disabled-bkg);
-  --fs-toggle-disabled-border-color            : var(--fs-border-color-default-disabled);
+  --fs-toggle-disabled-border-color            : var(--fs-border-color-disabled);
 
   // --------------------------------------------------------
   // Structural Styles


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR removes some unused `-default` variables that are being used on our code. This nomenclature was removed at #51 but after [this PR discussion](https://github.com/vtex-sites/nextjs.store/pull/61#discussion_r885095969), I've found out that #67 brings some of them back.

## How does it work?

This PR just removes the `-default` nomenclature from variables where it's possible.

## How to test it?

Look around the preview and storybook. It should be working with the variables.

## References
- https://github.com/vtex-sites/nextjs.store/pull/61#discussion_r885095969)

## Checklist

<em>You may erase this after checking them all ;)</em>

- [ ] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [ ] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 


- PR description
- [ ] Updated the Storybook - *if applicable*.
- [ ] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [ ] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [ ] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.
- [ ] For documentation changes, ping @carolinamenezes or @Mariana-Caetano to review and update the changes.

