### PR TITLE
fix: Static incremental builds errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Lighthouse complaining about missing robots.txt ([#89](https://github.com/vtex-sites/nextjs.store/pull/89))
+- Fix 404 being returned for existing pages when the server fails to fetch data ([#88](https://github.com/vtex-sites/nextjs.store/pull/88))
 - Search suggestions missing locale info ([#71](https://github.com/vtex-sites/nextjs.store/pull/71))
 - Limit custom props only for `img` and `link` tags ([#60](https://github.com/vtex-sites/nextjs.store/pull/60))
 - Warning related to `fetchPriority` prop not being recognized as `img` and `link`'s prop ([#54](https://github.com/vtex-sites/nextjs.store/pull/54))

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -166,13 +166,17 @@ export const getStaticProps: GetStaticProps<
 > = async ({ params }) => {
   const slug = params?.slug.join('/') ?? ''
 
-  const { data } = await execute<
+  const { data, errors } = await execute<
     ServerCollectionPageQueryQueryVariables,
     ServerCollectionPageQueryQuery
   >({
     variables: { slug },
     operationName: query,
   })
+
+  if (errors?.length > 0) {
+    throw new Error(`${errors[0]}`)
+  }
 
   if (data === null) {
     return {

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -155,13 +155,17 @@ export const getStaticProps: GetStaticProps<
 > = async ({ params }) => {
   const id = params?.slug.split('-').pop() ?? ''
 
-  const { data } = await execute<
+  const { data, errors } = await execute<
     ServerProductPageQueryQueryVariables,
     ServerProductPageQueryQuery
   >({
     variables: { id },
     operationName: query,
   })
+
+  if (errors?.length > 0) {
+    throw new Error(`${errors[0]}`)
+  }
 
   if (data === null) {
     return {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,9 +1,9 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import {
   envelop,
+  useAsyncSchema,
   useExtendContext,
   useMaskedErrors,
-  useAsyncSchema,
 } from '@envelop/core'
 import type { FormatErrorHandler } from '@envelop/core'
 import { useGraphQlJit } from '@envelop/graphql-jit'

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,9 +1,9 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import {
   envelop,
-  useAsyncSchema,
   useExtendContext,
   useMaskedErrors,
+  useAsyncSchema,
 } from '@envelop/core'
 import type { FormatErrorHandler } from '@envelop/core'
 import { useGraphQlJit } from '@envelop/graphql-jit'


### PR DESCRIPTION
## What's the purpose of this pull request?
Fix wrong 404 during SSG

## How does it work?
When an error occurs while fetching data needed for pages during SSG, our code threats this as a notFound. This notFound is SSG and this page will be notFound until we make a new deploy. This PR fixes this issue by throwing and error if an error occurs, making this page to be re-generated on the next request, thus generating the right page.

## How to test it?
1. Run `yarn build && yarn serve` on your machine
2. Remove internet access (disable wifi) from your machine to simulate a communication error between the server and VTEX commerce platform
3. Enter in a PDP. You should see the 500 error page.
4. Re-enable the wifi and refresh. You should now see the correct page.


