### PR TITLE
Chore: Adds `--docs` to storybook script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Uses `--docs` option on storybook script ([#107](https://github.com/vtex-sites/nextjs.store/pull/107))
 - Improves storybook doc's table rows ([#106](https://github.com/vtex-sites/nextjs.store/pull/106))
 - Changes weird if logic in suspense hooks ([#96](https://github.com/vtex-sites/nextjs.store/pull/96))
 - Adjust `Alert` component for `CMS` ([#31](https://github.com/vtex-sites/nextjs.store/pull/31))

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "stylelint:fix": "stylelint \"**/*.scss\" --fix",
     "postinstall": "is-ci || husky install",
     "partytown": "partytown copylib ./public/~partytown",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook --docs -p 6006",
     "build-storybook": "build-storybook"
   },
   "engines": {


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds `--docs` to `storybook` script so that we can see the same storybook structure locally and on production builds.

## Checklist

<em>You may erase this after checking them all ;)</em>

**Changelog**
- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*.
- [x] For documentation changes, ping @ carolinamenezes, @ PedroAntunesCosta or @ Mariana-Caetano to review and update.

