### PR TITLE
fix: Region Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `default` nomenclature from global tokens ([#51](https://github.com/vtex-sites/nextjs.store/pull/51))
 
 ### Fixed
-
+- Fix Region Input's behavior when setting zipCode ([#108](https://github.com/vtex-sites/nextjs.store/pull/108))
 - Lighthouse complaining about missing robots.txt ([#89](https://github.com/vtex-sites/nextjs.store/pull/89))
 - Fix 404 being returned for existing pages when the server fails to fetch data ([#88](https://github.com/vtex-sites/nextjs.store/pull/88))
 - Search suggestions missing locale info ([#71](https://github.com/vtex-sites/nextjs.store/pull/71))

--- a/src/components/regionalization/RegionalizationInput/RegionalizationInput.tsx
+++ b/src/components/regionalization/RegionalizationInput/RegionalizationInput.tsx
@@ -7,7 +7,7 @@ import { useModal } from 'src/sdk/ui/modal/Provider'
 
 export default function RegionalizationInput() {
   const inputRef = useRef<HTMLInputElement>(null)
-  const { setSession, ...session } = useSession()
+  const { setSession, isValidating, ...session } = useSession()
   const [errorMessage, setErrorMessage] = useState<string>('')
   const { onModalClose } = useModal()
 


### PR DESCRIPTION
## What's the purpose of this pull request?
Fix Region Input's behavior when setting zipCode

## How does it work?
When using `Mutation.validateSession` query, `RegionalizationInput` component was passing an extra variable that was not defined on the GraphQL schema, breaking the query with the following error:
<img width="979" alt="image" src="https://user-images.githubusercontent.com/1753396/172620973-cb5a3abf-e6c8-437e-825d-2ebb1f47a90f.png">

This PR addresses this issue by removing the `isValidating` variable from session.

## How to test it?
Open the deploy preview, set the zip code and make sure the zip code is set on the UI without errors on console like so:
![zip](https://user-images.githubusercontent.com/1753396/172622303-1a4cb05a-5c4b-4670-965f-3484df3d8468.gif)


