### PR TITLE
chore: Add support new types from React 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for the new type definitions from Reacr 18 ([#113](https://github.com/vtex-sites/nextjs.store/pull/113)).
 - Creates new Storybook section `BestPractices` ([#101](https://github.com/vtex-sites/nextjs.store/pull/101))
 - Applies new local tokens to `OutOfStock` ([#97](https://github.com/vtex-sites/nextjs.store/pull/97))
 - Applies new local tokens to `CartItem` ([#102](https://github.com/vtex-sites/nextjs.store/pull/102))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for the new type definitions from Reacr 18 ([#113](https://github.com/vtex-sites/nextjs.store/pull/113)).
+- Support for the new type definitions from React 18 ([#113](https://github.com/vtex-sites/nextjs.store/pull/113)).
 - Creates new Storybook section `BestPractices` ([#101](https://github.com/vtex-sites/nextjs.store/pull/101))
 - Applies new local tokens to `OutOfStock` ([#97](https://github.com/vtex-sites/nextjs.store/pull/97))
 - Applies new local tokens to `CartItem` ([#102](https://github.com/vtex-sites/nextjs.store/pull/102))

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "webpack": "^5.72.0"
   },
   "resolutions": {
-    "@types/react": "^17.x"
+    "@types/react": "^18.x"
   },
   "lint-staged": {
     "*.{ts,js,tsx,jsx}": [

--- a/src/components/sections/Hero/Hero.stories.tsx
+++ b/src/components/sections/Hero/Hero.stories.tsx
@@ -1,5 +1,3 @@
-import { HelmetProvider } from 'react-helmet-async'
-
 import Icon from 'src/components/ui/Icon'
 
 import type { HeroProps } from '.'
@@ -15,11 +13,7 @@ const story = {
   },
 }
 
-const Template = ({ ...args }: HeroProps) => (
-  <HelmetProvider>
-    <Hero {...args} />
-  </HelmetProvider>
-)
+const Template = ({ ...args }: HeroProps) => <Hero {...args} />
 
 export const Primary = Template.bind({})
 

--- a/src/sdk/error/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/sdk/error/ErrorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { Component } from 'react'
-import type { ErrorInfo } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
 
 const getReloads = () =>
   Number(window.sessionStorage.getItem('store:reloads') ?? '0')
@@ -15,7 +15,7 @@ if (typeof window !== 'undefined') {
   window.setInterval(() => setReloads(0), 30e3)
 }
 
-class ErrorBoundary extends Component {
+class ErrorBoundary extends Component<{ children: ReactNode }> {
   public state = { hasError: false, error: null }
 
   public static getDerivedStateFromError(error: Error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3810,10 +3810,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.x":
-  version "17.0.44"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
-  integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
+"@types/react@*", "@types/react@^18.x":
+  version "18.0.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.12.tgz#cdaa209d0a542b3fcf69cf31a03976ec4cdd8840"
+  integrity sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
## How does it work?

I had tried using a new feature from React 18 called `useDeferredValue` but got a type error `Module '"react"' has no exported member 'useDeferredValue'.`. I started by [updating the type definitions from 17.x to 18.x](https://github.com/vtex-sites/nextjs.store/commit/8955ce3e42c676ffbc7eeb6d75d4d0479d6c1a97) but got another [type error with `HelmetProvider`](https://github.com/vtex-sites/nextjs.store/runs/6828783453). I was able to [remove it](https://github.com/vtex-sites/nextjs.store/commit/eb0f3f91e05a6229b4bc49bb0383625d5a55b447) as it was not really needed, but the build failed again in the next [type error in `ErrorBoundary`](https://github.com/vtex-sites/nextjs.store/runs/6828844458). Finally, after [adjusting the missing type](https://github.com/vtex-sites/nextjs.store/commit/c5fbda5059e18d353af141eb5a4b33dd8b0e9ecb), I got everything working and with support for React 18 types.

## How to test it?

Try to use any new React 18 features and their types should not fail to compile the build.