### PR TITLE
fix: Minor accessibility warnings

### DIFF
--- a/src/components/common/Footer/FooterLinks.tsx
+++ b/src/components/common/Footer/FooterLinks.tsx
@@ -6,6 +6,7 @@ import Accordion, { AccordionItem } from 'src/components/ui/Accordion'
 
 const links = [
   {
+    id: 'footer-our-company',
     title: 'Our company',
     items: [
       {
@@ -27,6 +28,7 @@ const links = [
     ],
   },
   {
+    id: 'footer-orders-and-purchases',
     title: 'Orders & Purchases',
     items: [
       {
@@ -48,6 +50,7 @@ const links = [
     ],
   },
   {
+    id: 'footer-support-and-services',
     title: 'Support & Services',
     items: [
       {
@@ -65,6 +68,7 @@ const links = [
     ],
   },
   {
+    id: 'footer-partnership',
     title: 'Partnerships',
     items: [
       {
@@ -139,8 +143,10 @@ function FooterLinks() {
       <div className="hidden-mobile">
         <div className="footer__links-columns">
           {links.map((section) => (
-            <nav key={section.title}>
-              <p className="text__title-mini">{section.title}</p>
+            <nav key={section.title} aria-labelledby={section.id}>
+              <p className="text__title-mini" id={section.id}>
+                {section.title}
+              </p>
               <LinksList items={section.items} />
             </nav>
           ))}

--- a/src/components/sections/Hero/Hero.tsx
+++ b/src/components/sections/Hero/Hero.tsx
@@ -55,10 +55,10 @@ const Hero = ({
             sizes="(max-width: 768px) 70vw, 50vw"
           />
         </UIHeroImage>
-        <UIHeroHeading data-fs-hero-heading aria-labelledby="hero-heading">
+        <UIHeroHeading data-fs-hero-heading>
           <div data-fs-hero-wrapper className="layout__content">
             <div data-fs-hero-info>
-              <h1 id="hero-heading">{title}</h1>
+              <h1>{title}</h1>
               <p data-fs-hero-text-body>{subtitle}</p>
               {!!link && (
                 <ButtonLink href={link} inverse={colorVariant === 'main'}>


### PR DESCRIPTION
## What's the purpose of this pull request?

Fix some minor accessibility warnings reported by [axe DevTools](https://deque.com/axe/devtools/):
1. Ensure the `nav` landmarks with links in the footer are unique.
2. Fix an invalid use of the `aria-labelledby` attribute in a `header` element without a `role` in the `Hero` component.

1|2
-|-
![CleanShot 2022-06-22 at 14 48 10](https://user-images.githubusercontent.com/381395/175105887-5dfc9099-2a76-40b1-bd23-63cab9f4ee4c.png)|![CleanShot 2022-06-22 at 14 48 58](https://user-images.githubusercontent.com/381395/175105924-42849f96-d38b-4fa6-8c81-dafc15e56a13.png)

## References

- https://dequeuniversity.com/rules/axe/4.4/landmark-unique
- https://dequeuniversity.com/rules/axe/4.4/aria-allowed-attr