### PR TITLE
fix: Transfers responsibility of `InputText`'s main attributes and callbacks to the renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - priceCurrency field on SEO meta data ([#161](https://github.com/vtex-sites/nextjs.store/pull/161))
 
+- Transfers responsibility of `InputText`'s main attributes and callbacks to the renderer ([#163](https://github.com/vtex-sites/nextjs.store/pull/163))
+
 ## [22.26.0.beta] - 2022-07-01
 
 ### Added

--- a/src/components/regionalization/RegionalizationInput/RegionalizationInput.tsx
+++ b/src/components/regionalization/RegionalizationInput/RegionalizationInput.tsx
@@ -12,6 +12,7 @@ function RegionInput({ closeModal }: Props) {
   const inputRef = useRef<HTMLInputElement>(null)
   const { setSession, isValidating, ...session } = useSession()
   const [errorMessage, setErrorMessage] = useState<string>('')
+  const [input, setInput] = useState<string>('')
 
   const handleSubmit = async () => {
     const value = inputRef.current?.value
@@ -43,10 +44,16 @@ function RegionInput({ closeModal }: Props) {
       <InputText
         inputRef={inputRef}
         id="postal-code-input"
-        errorMessage={errorMessage}
+        error={errorMessage}
         label="Zip Code"
         actionable
+        value={input}
+        onInput={(e) => {
+          errorMessage !== '' && setErrorMessage('')
+          setInput(e.currentTarget.value)
+        }}
         onSubmit={handleSubmit}
+        onClear={() => setInput('')}
       />
     </div>
   )

--- a/src/components/ui/InputText/InputText.stories.tsx
+++ b/src/components/ui/InputText/InputText.stories.tsx
@@ -13,6 +13,9 @@ const story = {
     id: {
       type: { name: 'string', required: true },
     },
+    onClear: {
+      table: { disable: true },
+    },
   },
 }
 
@@ -30,7 +33,7 @@ export const Disabled = Template.bind({})
 Default.args = {
   id: 'default-input-text',
   label: 'Email',
-  errorMessage: 'Please, add a valid email',
+  error: 'Please, add a valid email',
   disabled: false,
 }
 
@@ -38,7 +41,7 @@ HasError.args = {
   id: 'error-input-text',
   label: 'Email',
   value: 'invalid@mail',
-  errorMessage: 'Please, add a valid email',
+  error: 'Please, add a valid email',
   disabled: false,
 }
 
@@ -46,14 +49,14 @@ Actionable.args = {
   id: 'actionable-input-text',
   label: 'Postal Code',
   actionable: true,
-  errorMessage: 'Invalid Postal Code',
+  error: 'Invalid Postal Code',
   disabled: false,
 }
 
 Disabled.args = {
   id: 'disabled-input-text',
   label: 'Email',
-  errorMessage: 'Please, add a valid email',
+  error: 'Please, add a valid email',
   disabled: true,
 }
 

--- a/src/components/ui/InputText/InputText.stories.tsx
+++ b/src/components/ui/InputText/InputText.stories.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import type { InputTextProps } from '.'
 import InputText from '.'
 
@@ -13,9 +15,6 @@ const story = {
     id: {
       type: { name: 'string', required: true },
     },
-    onClear: {
-      table: { disable: true },
-    },
   },
 }
 
@@ -25,15 +24,39 @@ const Template = ({ ...args }: InputTextProps) => (
   </div>
 )
 
+const TemplateActionable = ({ ...args }: InputTextProps) => {
+  const [input, setInput] = useState('')
+  const [error, setError] = useState<string>()
+
+  return (
+    <div style={{ width: 400 }}>
+      <InputText
+        actionable
+        error={error}
+        value={input}
+        onSubmit={() => setError('Invalid Postal Code')}
+        onClear={() => {
+          setError(undefined)
+          setInput('')
+        }}
+        onChange={(e) => {
+          error && setError(undefined)
+          setInput(e.target.value)
+        }}
+        {...args}
+      />
+    </div>
+  )
+}
+
 export const Default = Template.bind({})
 export const HasError = Template.bind({})
-export const Actionable = Template.bind({})
+export const Actionable = TemplateActionable.bind({})
 export const Disabled = Template.bind({})
 
 Default.args = {
   id: 'default-input-text',
   label: 'Email',
-  error: 'Please, add a valid email',
   disabled: false,
 }
 
@@ -48,8 +71,6 @@ HasError.args = {
 Actionable.args = {
   id: 'actionable-input-text',
   label: 'Postal Code',
-  actionable: true,
-  error: 'Invalid Postal Code',
   disabled: false,
 }
 

--- a/src/components/ui/InputText/InputText.stories.tsx
+++ b/src/components/ui/InputText/InputText.stories.tsx
@@ -15,6 +15,9 @@ const story = {
     id: {
       type: { name: 'string', required: true },
     },
+    actionable: {
+      type: { name: 'boolean' },
+    },
   },
 }
 
@@ -57,7 +60,6 @@ export const Disabled = Template.bind({})
 Default.args = {
   id: 'default-input-text',
   label: 'Email',
-  disabled: false,
 }
 
 HasError.args = {
@@ -65,19 +67,16 @@ HasError.args = {
   label: 'Email',
   value: 'invalid@mail',
   error: 'Please, add a valid email',
-  disabled: false,
 }
 
 Actionable.args = {
   id: 'actionable-input-text',
   label: 'Postal Code',
-  disabled: false,
 }
 
 Disabled.args = {
   id: 'disabled-input-text',
   label: 'Email',
-  error: 'Please, add a valid email',
   disabled: true,
 }
 

--- a/src/components/ui/InputText/InputText.tsx
+++ b/src/components/ui/InputText/InputText.tsx
@@ -31,16 +31,22 @@ type DefaultProps = {
 
 type ActionableInputText =
   | {
+      actionable?: never
+      onSubmit?: never
+      onClear?: never
+      buttonActionText?: string
+    }
+  | {
       /**
        * Adds a Button to the component.
        */
       actionable: true
       /**
-       * Callback function when button is clicked.
+       * Callback function when button is clicked. Required for actionable input.
        */
       onSubmit: () => void
       /**
-       * Callback function when clear button is clicked.
+       * Callback function when clear button is clicked. Required for actionable input.
        */
       onClear: () => void
       /**
@@ -48,15 +54,9 @@ type ActionableInputText =
        */
       buttonActionText?: string
     }
-  | {
-      actionable?: false
-      onSubmit?: never
-      onClear?: never
-      buttonActionText?: string
-    }
 
 export type InputTextProps = DefaultProps &
-  Omit<InputProps, 'disabled'> &
+  Omit<InputProps, 'disabled' | 'onSubmit'> &
   ActionableInputText
 
 const InputText = ({
@@ -71,17 +71,19 @@ const InputText = ({
   placeholder = ' ', // initializes with an empty space to style float label using `placeholder-shown`
   inputRef,
   disabled,
+  value,
   ...otherProps
 }: InputTextProps) => {
   return (
     <div
       data-fs-input-text
-      data-fs-input-text-error={!!error}
       data-fs-input-text-actionable={actionable}
+      data-fs-input-text-error={error && error !== ''}
     >
       <UIInput
         id={id}
         type={type}
+        value={value}
         ref={inputRef}
         disabled={disabled}
         placeholder={placeholder}
@@ -91,13 +93,14 @@ const InputText = ({
 
       {actionable &&
         !disabled &&
+        value !== '' &&
         (error ? (
           <ButtonIcon
             data-fs-button-size="small"
             aria-label="Clear Field"
             icon={<Icon name="XCircle" width={20} height={20} />}
             onClick={() => {
-              onClear?.()
+              onClear()
               inputRef?.current?.focus()
             }}
           />
@@ -106,7 +109,9 @@ const InputText = ({
             {buttonActionText}
           </Button>
         ))}
-      {error && !disabled && <span data-fs-input-text-message>{error}</span>}
+      {!disabled && error && error !== '' && (
+        <span data-fs-input-text-message>{error}</span>
+      )}
     </div>
   )
 }

--- a/src/components/ui/InputText/InputText.tsx
+++ b/src/components/ui/InputText/InputText.tsx
@@ -74,6 +74,9 @@ const InputText = ({
   value,
   ...otherProps
 }: InputTextProps) => {
+  const shouldDisplayError = !disabled && error && error !== ''
+  const shouldDisplayButton = actionable && !disabled && value !== ''
+
   return (
     <div
       data-fs-input-text
@@ -91,16 +94,14 @@ const InputText = ({
       />
       <UILabel htmlFor={id}>{label}</UILabel>
 
-      {actionable &&
-        !disabled &&
-        value !== '' &&
+      {shouldDisplayButton &&
         (error ? (
           <ButtonIcon
             data-fs-button-size="small"
             aria-label="Clear Field"
             icon={<Icon name="XCircle" width={20} height={20} />}
             onClick={() => {
-              onClear()
+              onClear?.()
               inputRef?.current?.focus()
             }}
           />
@@ -109,9 +110,7 @@ const InputText = ({
             {buttonActionText}
           </Button>
         ))}
-      {!disabled && error && error !== '' && (
-        <span data-fs-input-text-message>{error}</span>
-      )}
+      {shouldDisplayError && <span data-fs-input-text-message>{error}</span>}
     </div>
   )
 }

--- a/src/components/ui/InputText/InputText.tsx
+++ b/src/components/ui/InputText/InputText.tsx
@@ -1,6 +1,5 @@
 import { Input as UIInput, Label as UILabel } from '@faststore/ui'
 import type { MutableRefObject } from 'react'
-import { useEffect, useState } from 'react'
 import type { InputProps } from '@faststore/ui'
 
 import Button from 'src/components/ui/Button'
@@ -19,7 +18,7 @@ type DefaultProps = {
   /**
    * The error message is displayed when an error occurs.
    */
-  errorMessage?: string
+  error?: string
   /**
    * Component's ref.
    */
@@ -39,7 +38,11 @@ type ActionableInputText =
       /**
        * Callback function when button is clicked.
        */
-      onSubmit: (value: string) => void
+      onSubmit: () => void
+      /**
+       * Callback function when clear button is clicked.
+       */
+      onClear: () => void
       /**
        * The text displayed on the Button. Suggestion: maximum 9 characters.
        */
@@ -48,6 +51,7 @@ type ActionableInputText =
   | {
       actionable?: false
       onSubmit?: never
+      onClear?: never
       buttonActionText?: string
     }
 
@@ -59,71 +63,50 @@ const InputText = ({
   id,
   label,
   type = 'text',
-  errorMessage,
+  error,
   actionable,
   buttonActionText = 'Apply',
   onSubmit,
+  onClear,
   placeholder = ' ', // initializes with an empty space to style float label using `placeholder-shown`
-  value,
   inputRef,
   disabled,
   ...otherProps
 }: InputTextProps) => {
-  const [inputValue, setInputValue] = useState<string>((value as string) ?? '')
-  const [hasError, setHasError] = useState<boolean>(!!errorMessage)
-
-  useEffect(() => {
-    errorMessage && setHasError(true)
-  }, [errorMessage])
-
-  const onClear = () => {
-    setInputValue('')
-    inputRef?.current?.focus()
-  }
-
   return (
     <div
       data-fs-input-text
-      data-fs-input-text-error={hasError && inputValue !== ''}
+      data-fs-input-text-error={!!error}
       data-fs-input-text-actionable={actionable}
     >
       <UIInput
-        type={type}
         id={id}
+        type={type}
         ref={inputRef}
-        placeholder={placeholder}
-        value={inputValue}
         disabled={disabled}
-        onInput={(e) => {
-          hasError && setHasError(false)
-          setInputValue(e.currentTarget.value)
-        }}
+        placeholder={placeholder}
         {...otherProps}
       />
       <UILabel htmlFor={id}>{label}</UILabel>
 
       {actionable &&
         !disabled &&
-        inputValue !== '' &&
-        (hasError ? (
+        (error ? (
           <ButtonIcon
             data-fs-button-size="small"
             aria-label="Clear Field"
             icon={<Icon name="XCircle" width={20} height={20} />}
-            onClick={onClear}
+            onClick={() => {
+              onClear?.()
+              inputRef?.current?.focus()
+            }}
           />
         ) : (
-          <Button
-            variant="tertiary"
-            onClick={() => onSubmit(inputValue)}
-            size="small"
-          >
+          <Button variant="tertiary" size="small" onClick={onSubmit}>
             {buttonActionText}
           </Button>
         ))}
-      {hasError && !disabled && inputValue !== '' && (
-        <span data-fs-input-text-message>{errorMessage}</span>
-      )}
+      {error && !disabled && <span data-fs-input-text-message>{error}</span>}
     </div>
   )
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the `InputText` by removing some component's local implementation, which should be the responsibility of the parent component that is rendering it.

## How does it work?

Previously, some main attributes were being defined inside `InputText` component (e.g. `onInput` and `value`) and by doing this, parent components rendering the `InputText` had limitations using the same attributes.

## How to test it?

The component should look the same as before. The main difference is the change of the responsibility to implement input's required attributes to the parent.

## Checklist

**Changelog**
- [x] Added an entry in the `CHANGELOG.md` at the beginning of its due section. [The latest version should comes first](https://keepachangelog.com/en/1.0.0/#:~:text=The%20latest%20version%20comes%20first.).
- [x] Added the PR number with the PR link at the entry in the `CHANGELOG.md`. E.g., *New items in the `pull_request_template.md` ([#4](https://github.com/vtex-sites/nextjs.store/pull/4))* 

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*.