### PR TITLE
chore: update release workflow to use bun

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
-          cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Configure CI Git User
@@ -34,7 +33,7 @@ jobs:
           git config user.email vtexgithubbot@github.com
 
       - name: Install dependencies
-        run: yarn
+        run: bun install
 
       - name: Release
-        run: yarn release
+        run: bun release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
           token: ${{ secrets.VTEX_GITHUB_BOT_TOKEN }}
           fetch-depth: 2
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v2
+      - name: Setup Bun environment
+        uses: xhyrom/setup-bun@v0.1.7
         with:
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
+          bun-version: latest
+          github-token: ${{ secrets.VTEX_GITHUB_BOT_TOKEN }}
 
       - name: Configure CI Git User
         run: |


### PR DESCRIPTION
## What's the purpose of this pull request?

The release workflow was using yarn, which caused yarn.lock to prevent it from creating the version bump commit. Using bun fixes the issue.

## How does it work?

Changes yarn commands for bun.