### PR TITLE
fix: Avoids performing the search when user abandons the query [FS-243]

### DIFF
--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -1,8 +1,8 @@
-import type { SearchInputRef } from '@faststore/ui'
 import { Suspense, useRef, useState } from 'react'
 
 import CartToggle from 'src/components/cart/CartToggle'
 import SearchInput from 'src/components/search/SearchInput'
+import type { SearchInputRef } from 'src/components/search/SearchInput'
 import Button, {
   ButtonSignIn,
   ButtonSignInFallback,
@@ -66,7 +66,10 @@ function Navbar() {
                 data-fs-button-collapse
                 aria-label="Collapse search bar"
                 icon={<Icon name="CaretLeft" width={32} height={32} />}
-                onClick={() => setSearchExpanded(false)}
+                onClick={() => {
+                  setSearchExpanded(false)
+                  searchMobileRef.current?.resetSearchInput()
+                }}
               />
             )}
             <SearchInput

--- a/src/components/search/SearchInput/SearchInput.tsx
+++ b/src/components/search/SearchInput/SearchInput.tsx
@@ -9,11 +9,12 @@ import {
   useRef,
   useState,
   useDeferredValue,
+  useImperativeHandle,
 } from 'react'
 import type { SearchEvent } from '@faststore/sdk'
 import type {
   SearchInputProps as UISearchInputProps,
-  SearchInputRef,
+  SearchInputRef as UISearchInputRef,
 } from '@faststore/ui'
 
 import Icon from 'src/components/ui/Icon'
@@ -34,6 +35,8 @@ export type SearchInputProps = {
   buttonTestId?: string
   containerStyle?: CSSProperties
 } & Omit<UISearchInputProps, 'onSubmit'>
+
+export type SearchInputRef = UISearchInputRef & { resetSearchInput: () => void }
 
 const sendAnalytics = async (term: string) => {
   sendAnalyticsEvent<SearchEvent>({
@@ -58,6 +61,10 @@ const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
     const searchRef = useRef<HTMLDivElement>(null)
     const { addToSearchHistory } = useSearchHistory()
     const router = useRouter()
+
+    useImperativeHandle(ref, () => ({
+      resetSearchInput: () => setSearchQuery(''),
+    }))
 
     const onSearchInputSelection: SearchInputContextValue['onSearchInputSelection'] =
       (term, path) => {

--- a/src/components/search/SearchInput/index.tsx
+++ b/src/components/search/SearchInput/index.tsx
@@ -1,2 +1,2 @@
 export { default } from './SearchInput'
-export type { SearchInputProps } from './SearchInput'
+export type { SearchInputProps, SearchInputRef } from './SearchInput'


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix the behavior when users abandon the search query and then click on the search icon again, automatically performing the search with the previous query.

Note that this behavior only happens and will be fixed in the mobile version. For the desktop version, the `SearchInput` bar persists what the user typed but without doing the automatic search.

## How does it work?

With these changes, an imperative handle was created for the `SearchInput` ref used in the `Navbar` component, so when users cancel the search action this handler is triggered and clears the input.

## How to test it?

Steps to reproduce (mobile version):
- Expand the search input and type anything;
- Close the search input by clicking on the left arrow icon;
- Expand the search input and the search won't be performed anymore.

Before|After
-|-
![CleanShot 2022-03-30 at 21 44 29-20220331-004533](https://user-images.githubusercontent.com/15722605/182420410-9b235804-e036-4a18-94c6-d8ccb0854e41.gif)|![Screen Recording 2022-08-02 at 13 00 10](https://user-images.githubusercontent.com/15722605/182421419-d1a63940-cb12-4011-87f6-f25bbcf038c6.gif)


## Checklist

**PR Title and Commit Messages**
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Enhancement`, `Bug` or `Chore`.
- [x] Added the component, hook, or pathname in-between backticks (``) *- If applicable*. E.g., *`ComponentName` component*.
- [x] Identified the function or parameter in the PR *- If applicable*. E.g., *`useWindowDimensions` hook*.

**Documentation**
- [x] PR description