### PR TITLE
fix: Attempt to fix the automated changelog update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,12 @@ jobs:
           token: ${{ secrets.VTEX_GITHUB_BOT_TOKEN }}
           fetch-depth: 2
 
-      - name: Setup Bun environment
-        uses: xhyrom/setup-bun@v0.1.7
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2
         with:
-          bun-version: latest
-          github-token: ${{ secrets.VTEX_GITHUB_BOT_TOKEN }}
+          node-version: 16
+          cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Configure CI Git User
         run: |
@@ -33,7 +34,7 @@ jobs:
           git config user.email vtexgithubbot@github.com
 
       - name: Install dependencies
-        run: bun install
+        run: yarn
 
       - name: Release
-        run: bun release
+        run: yarn release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           git config user.email vtexgithubbot@github.com
 
       - name: Install dependencies
-        run: yarn
+        run: yarn install --verbose
 
       - name: Release
         run: yarn release


### PR DESCRIPTION
## What's the purpose of this pull request?

Unfortunately, the last attempt (https://github.com/vtex-sites/nextjs.store/pull/195) [did not work](https://github.com/vtex-sites/nextjs.store/runs/7654765639?check_suite_focus=true). So it wasn't about the `bun.lockb` file not being committed...
![CleanShot 2022-08-03 at 12 15 00](https://user-images.githubusercontent.com/381395/182644610-74d81900-6518-45cb-9ee1-c7fb40950068.png)

My next attempt is to revert https://github.com/vtex-sites/nextjs.store/pull/186 so we can use `yarn` again, as we do in the [Gatsby's one](https://github.com/vtex-sites/gatsby.store/blob/8d1b1a5d668b11578784c29a9b257c78c86a1a65/.github/workflows/release.yml#L24-L29) and it's working there. I suspect [it didn't work](https://github.com/vtex-sites/nextjs.store/runs/7585048684?check_suite_focus=true) because we had an uncommitted `yarn.lock` file.

## How to test it?

The workflow only runs when pushed to `main`, so we'll have to merge and check.

## References

- https://github.com/vtex-sites/nextjs.store/pull/195
- https://github.com/vtex-sites/nextjs.store/pull/186
- https://github.com/vtex-sites/nextjs.store/pull/184
- https://github.com/vtex-sites/gatsby.store/compare/2ce858d20c6baddffac294503a89396324a49929~1...8423be3df7da4dc04d84f1b89fc4f6564ca476ba~1