### PR TITLE
chore: Renames/Updates border tokens

### DIFF
--- a/src/components/ui/ShippingSimulation/ShippingSimulation.stories.mdx
+++ b/src/components/ui/ShippingSimulation/ShippingSimulation.stories.mdx
@@ -148,6 +148,6 @@ The `ShippingSimulation` component uses [FastStore UI Table](https://www.faststo
   />
   <TokenRow
     token="--fs-shipping-simulation-table-cell-border-radius"
-    value=".25rem"
+    value="var(--fs-border-radius)"
   />
 </TokenTable>

--- a/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
+++ b/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
@@ -35,7 +35,7 @@
 
   --fs-shipping-simulation-table-cell-padding       : var(--fs-spacing-2);
   --fs-shipping-simulation-table-cell-text-size     : var(--fs-text-size-2);
-  --fs-shipping-simulation-table-cell-border-radius : .25rem;
+  --fs-shipping-simulation-table-cell-border-radius : var(--fs-border-radius);
 
   font-size: var(--fs-shipping-simulation-font-size);
 

--- a/src/stories/refinements.stories.mdx
+++ b/src/stories/refinements.stories.mdx
@@ -31,8 +31,8 @@ import {
 ## Borders
 
 <TokenTable title="Global Token" description="Value">
-  <TokenRow token="--fs-border-radius-small" value=".125rem" />
-  <TokenRow token="--fs-border-radius" value=".25rem" />
+  <TokenRow token="--fs-border-radius-small" value="1px" />
+  <TokenRow token="--fs-border-radius" value=".125rem" />
   <TokenRow token="--fs-border-radius-medium" value=".5rem" />
   <TokenRow token="--fs-border-radius-pill" value="100px" />
   <TokenRow token="--fs-border-radius-circle" value="100%" />

--- a/src/stories/refinements.stories.mdx
+++ b/src/stories/refinements.stories.mdx
@@ -32,7 +32,7 @@ import {
 
 <TokenTable title="Global Token" description="Value">
   <TokenRow token="--fs-border-radius-small" value=".125rem" />
-  <TokenRow token="--fs-border-radius" value=".125rem" />
+  <TokenRow token="--fs-border-radius" value=".25rem" />
   <TokenRow token="--fs-border-radius-medium" value=".5rem" />
   <TokenRow token="--fs-border-radius-pill" value="100px" />
   <TokenRow token="--fs-border-radius-circle" value="100%" />

--- a/src/styles/global/tokens.scss
+++ b/src/styles/global/tokens.scss
@@ -250,7 +250,7 @@ body {
 
   // BORDERS
   --fs-border-radius-small             : .125rem; // 2px
-  --fs-border-radius                   : .125rem; // 2px
+  --fs-border-radius                   : .25rem;  // 4px
   --fs-border-radius-medium            : .5rem;   // 8px
   --fs-border-radius-pill              : 100px;
   --fs-border-radius-circle            : 100%;

--- a/src/styles/global/tokens.scss
+++ b/src/styles/global/tokens.scss
@@ -249,8 +249,8 @@ body {
   --fs-transition-function             : ease-in-out;
 
   // BORDERS
-  --fs-border-radius-small             : .125rem; // 2px
-  --fs-border-radius                   : .25rem;  // 4px
+  --fs-border-radius-small             : 1px;     // 1px
+  --fs-border-radius                   : .125rem; // 2px
   --fs-border-radius-medium            : .5rem;   // 8px
   --fs-border-radius-pill              : 100px;
   --fs-border-radius-circle            : 100%;


### PR DESCRIPTION
## What's the purpose of this pull request?

Removes duplication for border tokens values (`--fs-border-radius-small` and `--fs-border-radius`)

![image](https://user-images.githubusercontent.com/3356699/185057304-fffe0f16-6430-4b46-8753-9669bee680fc.png)

After confirming on our [Figma](https://www.figma.com/file/FGvF9W13k5UkrIq75n1oCU/Brandless-Library?node-id=3720%3A145035) file, the default one is `--fs-border-radius` is .25rem (4px).

## How does it work?

Updates `--fs-border-radius` to  .25rem (4px)

## How to test it?

Check on the storybook preview if the values are updated according.

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**
- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`
- [ ] Added the component, hook, or path name in-between backticks (\`\`) - *if applicable, e.g., `ComponentName` component, `useWindowDimensions` hook*

**Dependencies**
- [ ] Committed the `yarn.lock` and `bun.lockb` file when there were changes to the packages

**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*
- [ ] For documentation changes, ping `@carolinamenezes` or `@PedroAntunesCosta` to review and update
