### PR TITLE
fix: Fix cms config

### DIFF
--- a/cms/sections.json
+++ b/cms/sections.json
@@ -66,6 +66,18 @@
         "actionLabel": {
           "type": "string",
           "title": "Action label"
+        },
+        "colorVariant": {
+          "type": "string",
+          "title": "Color Variant",
+          "enumNames": ["Main", "Light", "Accent"],
+          "enum": ["main", "light", "accent"]
+        },
+        "variant": {
+          "type": "string",
+          "title": "Variant",
+          "enumNames": ["Primary", "Secondary"],
+          "enum": ["primary", "secondary"]
         }
       }
     }
@@ -110,16 +122,17 @@
     "schema": {
       "title": "Incentives Header",
       "description": "Add Incentives to your shopper",
-      "required": ["firstLineText", "icon"],
       "type": "object",
       "properties": {
         "incentives": {
+          "title": "Incentives",
           "type": "array",
           "minItems": 3,
           "maxItems": 5,
           "items": {
             "title": "Incentive",
             "type": "object",
+            "required": ["title", "firstLineText", "icon"],
             "properties": {
               "title": {
                 "type": "string",
@@ -179,7 +192,7 @@
           "type": "string",
           "title": "After",
           "default": "0",
-          "description": "Initial pagination item"
+          "description": "Initial paginatio item"
         },
         "sort": {
           "title": "Sort",
@@ -258,7 +271,7 @@
           "type": "string",
           "title": "After",
           "default": "0",
-          "description": "Initial pagination item"
+          "description": "Initial paginatio item"
         },
         "sort": {
           "title": "Sort",

--- a/cms/sections.json
+++ b/cms/sections.json
@@ -192,7 +192,7 @@
           "type": "string",
           "title": "After",
           "default": "0",
-          "description": "Initial paginatio item"
+          "description": "Initial pagination item"
         },
         "sort": {
           "title": "Sort",
@@ -271,7 +271,7 @@
           "type": "string",
           "title": "After",
           "default": "0",
-          "description": "Initial paginatio item"
+          "description": "Initial pagination item"
         },
         "sort": {
           "title": "Sort",


### PR DESCRIPTION
Signed-off-by: Arthur Andrade <arthurfelandrade@gmail.com>

## What's the purpose of this pull request?

This PR fix the config from storeframework CMS to be possible adds the IncentivesHeader and BannerText variant.

## How does it work?

Fix sections.json config.

## How to test it?

View the [preview](https://sfj-e9ba42b--nextjs.preview.vtex.app/office) and use the [Storeframework CMS.]( https://storeframework.myvtex.com/admin/new-cms/faststore/home/edit/ad2fd81d-a53c-4281-8d01-a4fc2f274db3/)

## References

https://www.faststore.dev/tutorials/cms/3

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**
- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`
- [ ] Added the component, hook, or path name in-between backticks (\`\`) - *if applicable, e.g., `ComponentName` component, `useWindowDimensions` hook*

**Dependencies**
- [ ] Committed the `yarn.lock` and `bun.lockb` file when there were changes to the packages

**Documentation**
- [ ] PR description
- [ ] Added to/Updated the Storybook - *if applicable*
- [ ] For documentation changes, ping `@carolinamenezes` or `@PedroAntunesCosta` to review and update
