### PR TITLE
chore: Updates border values to px

### DIFF
--- a/src/stories/refinements.stories.mdx
+++ b/src/stories/refinements.stories.mdx
@@ -32,8 +32,8 @@ import {
 
 <TokenTable title="Global Token" description="Value">
   <TokenRow token="--fs-border-radius-small" value="1px" />
-  <TokenRow token="--fs-border-radius" value=".125rem" />
-  <TokenRow token="--fs-border-radius-medium" value=".5rem" />
+  <TokenRow token="--fs-border-radius" value="2px" />
+  <TokenRow token="--fs-border-radius-medium" value="8px" />
   <TokenRow token="--fs-border-radius-pill" value="100px" />
   <TokenRow token="--fs-border-radius-circle" value="100%" />
   <TokenDivider />

--- a/src/styles/global/tokens.scss
+++ b/src/styles/global/tokens.scss
@@ -249,9 +249,9 @@ body {
   --fs-transition-function             : ease-in-out;
 
   // BORDERS
-  --fs-border-radius-small             : 1px;     // 1px
-  --fs-border-radius                   : .125rem; // 2px
-  --fs-border-radius-medium            : .5rem;   // 8px
+  --fs-border-radius-small             : 1px;
+  --fs-border-radius                   : 2px;
+  --fs-border-radius-medium            : 8px;
   --fs-border-radius-pill              : 100px;
   --fs-border-radius-circle            : 100%;
 


### PR DESCRIPTION
## What's the purpose of this pull request?

- Updates border tokens values to px
https://github.com/vtex-sites/nextjs.store/pull/208 Follow-up. Applying remaining [changes](https://github.com/vtex-sites/gatsby.store/pull/184/commits/543d9442749d000b61b54f8dba2294974aacd416
)

## How does it work?

Uses `px` unit.

## How to test it?

Check on the storybook preview if the values are updated according. 

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**
- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`
- [x] Added the component, hook, or path name in-between backticks (\`\`) - *if applicable, e.g., `ComponentName` component, `useWindowDimensions` hook*

**Dependencies**
- [ ] Committed the `yarn.lock` and `bun.lockb` file when there were changes to the packages

**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*
- [ ] For documentation changes, ping `@carolinamenezes` or `@PedroAntunesCosta` to review and update
