### PR TITLE
fix build warnings

### DIFF
--- a/src/components/cms/RenderPageSections.tsx
+++ b/src/components/cms/RenderPageSections.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { ComponentType } from 'react'
 
 import BannerText from 'src/components/sections/BannerText'
@@ -19,7 +20,7 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
 }
 
 interface Props {
-  sections?: Array<{ name: string; data: unknown }>
+  sections?: Array<{ name: string; data: any }>
 }
 
 function RenderPageSections({ sections }: Props) {
@@ -36,7 +37,7 @@ function RenderPageSections({ sections }: Props) {
           return <></>
         }
 
-        return <Component key={`cms-section-${index}`} {...(data as any)} />
+        return <Component key={`cms-section-${index}`} {...data} />
       })}
     </>
   )


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR fixes the warnings below:
```
$ yarn partytown && next build
$ partytown copylib ./public/~partytown
Partytown lib copied to: /shared/project/public/~partytown
info  - Linting and checking validity of types...

./src/components/cms/RenderPageSections.tsx
13:48  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
39:69  Warning: Unexpected any. Specify a different type.  @typescript-eslint/no-explicit-any
```

I tried other techniques to avoid disabling this rule now, however, I couldn't properly type it. If you know something better, please let me know