### PR TITLE
Fix: `ShippingSimulation` tokens

### DIFF
--- a/src/components/ui/ShippingSimulation/ShippingSimulation.stories.mdx
+++ b/src/components/ui/ShippingSimulation/ShippingSimulation.stories.mdx
@@ -53,7 +53,7 @@ The `ShippingSimulation` component uses [FastStore UI Table](https://www.faststo
 
 <TokenTable>
   <TokenRow
-    token="--fs-shipping-simulation-font-size"
+    token="--fs-shipping-simulation-text-size"
     value="var(--fs-text-size-legend)"
   />
 </TokenTable>
@@ -93,11 +93,11 @@ The `ShippingSimulation` component uses [FastStore UI Table](https://www.faststo
 
 <TokenTable>
   <TokenRow
-    token="--fs-shipping-simulation-subtitle-text-size"
+    token="--fs-shipping-simulation-subtitle-size"
     value="var(--fs-text-size-2)"
   />
   <TokenRow
-    token="--fs-shipping-simulation-subtitle-text-weight"
+    token="--fs-shipping-simulation-subtitle-weight"
     value="var(--fs-text-weight-bold)"
   />
   <TokenRow token="--fs-shipping-simulation-subtitle-line-height" value="1.5" />

--- a/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
+++ b/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
@@ -6,7 +6,7 @@
   // --------------------------------------------------------
 
   // Default properties
-  --fs-shipping-simulation-font-size                : var(--fs-text-size-legend);
+  --fs-shipping-simulation-text-size                : var(--fs-text-size-legend);
 
   // Title
   --fs-shipping-simulation-title-padding-bottom     : var(--fs-spacing-2);
@@ -18,8 +18,8 @@
   --fs-shipping-simulation-header-padding-top       : var(--fs-spacing-3);
 
   // Subtitle
-  --fs-shipping-simulation-subtitle-text-size       : var(--fs-text-size-2);
-  --fs-shipping-simulation-subtitle-text-weight     : var(--fs-text-weight-bold);
+  --fs-shipping-simulation-subtitle-size       : var(--fs-text-size-2);
+  --fs-shipping-simulation-subtitle-weight     : var(--fs-text-weight-bold);
   --fs-shipping-simulation-subtitle-line-height     : 1.5;
 
   // Location
@@ -37,7 +37,7 @@
   // Structural Styles
   // --------------------------------------------------------
 
-  font-size: var(--fs-shipping-simulation-font-size);
+  font-size: var(--fs-shipping-simulation-text-size);
 
   [data-fs-shipping-simulation-title] {
     padding-bottom: var(--fs-shipping-simulation-title-padding-bottom);
@@ -58,8 +58,8 @@
   }
 
   [data-fs-shipping-simulation-subtitle] {
-    font-size: var(--fs-shipping-simulation-subtitle-text-size);
-    font-weight: var(--fs-shipping-simulation-subtitle-text-weight);
+    font-size: var(--fs-shipping-simulation-subtitle-size);
+    font-weight: var(--fs-shipping-simulation-subtitle-weight);
     line-height: var(--fs-shipping-simulation-subtitle-line-height);
   }
 

--- a/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
+++ b/src/components/ui/ShippingSimulation/shipping-simulation.module.scss
@@ -18,8 +18,8 @@
   --fs-shipping-simulation-header-padding-top       : var(--fs-spacing-3);
 
   // Subtitle
-  --fs-shipping-simulation-subtitle-size       : var(--fs-text-size-2);
-  --fs-shipping-simulation-subtitle-weight     : var(--fs-text-weight-bold);
+  --fs-shipping-simulation-subtitle-size            : var(--fs-text-size-2);
+  --fs-shipping-simulation-subtitle-weight          : var(--fs-text-weight-bold);
   --fs-shipping-simulation-subtitle-line-height     : 1.5;
 
   // Location


### PR DESCRIPTION
## What's the purpose of this pull request?
Tiny PR to improve `ShippingSimulation` text tokens.

## How does it work?
The component should look exactly the same.
|Before|After|
|-|-|
|`--fs-shipping-simulation-font-size`|`--fs-shipping-simulation-text-size`|
|`--fs-shipping-simulation-subtitle-text-size`|`--fs-shipping-simulation-subtitle-size`|
|`--fs-shipping-simulation-subtitle-text-weight`|`--fs-shipping-simulation-subtitle-weight`|

## How to test it?
Review the updates on Storybook doc: [ShippingSimulation](https://nextjs-store-storybook-git-fix-shipping-simula-c9d67a-faststore.vercel.app/?path=/docs/features-shippingsimulation--default-story)

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**
- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`
- [x] Added the component, hook, or path name in-between backticks (\`\`) - *if applicable, e.g., `ComponentName` component, `useWindowDimensions` hook*
- [ ] 
**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*