### PR TITLE
fix: A regression with CLS on the Home page

### DIFF
--- a/src/components/sections/ProductShelf/ProductShelf.tsx
+++ b/src/components/sections/ProductShelf/ProductShelf.tsx
@@ -40,7 +40,7 @@ function ProductShelf({
     }
   }, [inView, productEdges.length, sendViewItemListEvent])
 
-  if (productEdges.length === 0) {
+  if (products?.edges.length === 0) {
     return null
   }
 

--- a/src/components/sections/ProductTiles/ProductTiles.tsx
+++ b/src/components/sections/ProductTiles/ProductTiles.tsx
@@ -52,7 +52,7 @@ const ProductTiles = ({ title, ...variables }: ProductTilesProps) => {
     }
   }, [inView, productEdges.length, sendViewItemListEvent])
 
-  if (productEdges.length === 0) {
+  if (products?.edges.length === 0) {
     return null
   }
 


### PR DESCRIPTION
## What's the purpose of this pull request?

https://github.com/vtex-sites/nextjs.store/pull/242 accidentally introduced a Cumulative Layout Shift (CLS) of ~0.2 on the Home page. This PR returns the CLS to 0.

Thanks @tlgimenes for noticing this!

## How does it work?

The CLS was introduced because the skeletons/placeholders weren't being used.

## How to test it?

[Before](https://sfj-2d694d6--nextjs.preview.vtex.app/)|[After](https://sfj-328f8c8--nextjs.preview.vtex.app/)
-|-
![CleanShot 2022-09-15 at 20 26 57](https://user-images.githubusercontent.com/381395/190525819-6c8efe74-e336-4182-9cc3-16d7e425088d.png)|![CleanShot 2022-09-15 at 20 27 02](https://user-images.githubusercontent.com/381395/190525872-76c359f3-ac97-4f6a-9d6c-5c834bf5a665.png)