### PR TITLE
fix: improve the execute server type

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks */
+import type { FormatErrorHandler } from '@envelop/core'
 import {
   envelop,
   useAsyncSchema,
@@ -8,10 +9,9 @@ import {
 import { useGraphQlJit } from '@envelop/graphql-jit'
 import { useParserCache } from '@envelop/parser-cache'
 import { useValidationCache } from '@envelop/validation-cache'
+import type { Maybe, Options as APIOptions } from '@faststore/api'
 import { getContextFactory, getSchema, isFastStoreError } from '@faststore/api'
 import { GraphQLError } from 'graphql'
-import type { FormatErrorHandler } from '@envelop/core'
-import type { Options as APIOptions } from '@faststore/api'
 
 import persisted from '../../@generated/graphql/persisted.json'
 import storeConfig from '../../store.config'
@@ -64,7 +64,7 @@ const getEnvelop = async () =>
 
 const envelopPromise = getEnvelop()
 
-export const execute = async <V, D>(
+export const execute = async <V extends Maybe<{ [key: string]: unknown }>, D>(
   options: ExecuteOptions<V>,
   envelopContext = { req: { headers: {} } }
 ): Promise<{ data: D; errors: unknown[] }> => {


### PR DESCRIPTION
## What's the purpose of this pull request?

this pr resolves the type in the server file


## How does it work?

the `execute` function takes two arguments `V` and `D` with V being the options and D being the context. However, V soon after is extracted into an object and the defined type did not foresee this causing the image below, so I add an extension to the V type so that it understands options as objects.

<img width="633" alt="Screen Shot 2022-09-19 at 13 04 11" src="https://user-images.githubusercontent.com/10627086/191062183-df04b113-7a8f-4461-b987-6da1db9ab1de.png">


## How to test it?

Checking if has ts any errors on file `src/server/index.ts`

## References

TS Docs

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**
- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`
- [x] Added the component, hook, or path name in-between backticks (\`\`) - *if applicable, e.g., `ComponentName` component, `useWindowDimensions` hook*

**Dependencies**
- [ ] Committed the `yarn.lock` and `bun.lockb` file when there were changes to the packages

**Documentation**
- [ ] PR description
- [ ] Added to/Updated the Storybook - *if applicable*
- [ ] For documentation changes, ping `@carolinamenezes` or `@PedroAntunesCosta` to review and update
