### PR TITLE
fix: `ImageGallery` height on responsive views

### DIFF
--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -532,3 +532,9 @@ header.sbdocs-hero + .sbdocs-callout {
   position: relative;
   z-index: 0;
 }
+
+@media screen and (min-width: 756px) {
+  .sbdocs-image-gallery > div > div:first-child {
+    padding: 1rem 13%;
+  }
+}

--- a/src/components/sections/ProductDetails/product-details.module.scss
+++ b/src/components/sections/ProductDetails/product-details.module.scss
@@ -145,15 +145,15 @@
     @include media(">=tablet") {
       grid-row: 1 / span 3;
       grid-column: span 7;
-      max-height: 380px;
+      max-height: 23.75rem;
     }
 
     @include media(">tablet", "<notebook") {
-      max-height: 560px;
+      max-height: 35rem;
     }
 
     @include media(">=notebook") {
-      max-height: 530px;
+      max-height: 33.125rem;
     }
 
     &[data-fs-image-gallery="without-selector"] {

--- a/src/components/ui/ImageGallery/ImageGallery.stories.mdx
+++ b/src/components/ui/ImageGallery/ImageGallery.stories.mdx
@@ -80,7 +80,7 @@ According to the quantity of `Image` to be displayed, the `ImageGallerySelector`
 
 `import { ImageGallery } from 'src/components/ui/ImageGallery'`
 
-<Canvas>
+<Canvas className="sbdocs-image-gallery">
   <Story name="default">{Template.bind({})}</Story>
 </Canvas>
 
@@ -104,7 +104,7 @@ According to the quantity of `Image` to be displayed, the `ImageGallerySelector`
 ### Current Selected Image
 
 <TokenTable>
-  <TokenRow token="--fs-image-gallery-current-max-height" value="33.125rem" />
+  <TokenRow token="--fs-image-gallery-current-height" value="33.125rem" />
   <TokenRow
     token="--fs-image-gallery-current-border-radius"
     value="var(--fs-border-radius)"
@@ -162,12 +162,12 @@ According to the quantity of `Image` to be displayed, the `ImageGallerySelector`
 
 ### With Selector (More than 1 Image)
 
-<Canvas>
+<Canvas className="sbdocs-image-gallery">
   <Story name="overview-default">{Template.bind({})}</Story>
 </Canvas>
 
 ### Without Selector
 
-<Canvas>
+<Canvas className="sbdocs-image-gallery">
   <Story name="overview-default-2">{TemplateWithoutSelector.bind({})}</Story>
 </Canvas>

--- a/src/components/ui/ImageGallery/image-gallery.module.scss
+++ b/src/components/ui/ImageGallery/image-gallery.module.scss
@@ -12,8 +12,8 @@
   --fs-image-gallery-gap-notebook              : var(--fs-spacing-3);
 
   // Current Selected Image
-  --fs-image-gallery-current-border-radius       : var(--fs-border-radius);
-  --fs-image-gallery-current-max-height          : 33.125rem;   // 530px
+  --fs-image-gallery-current-border-radius     : var(--fs-border-radius);
+  --fs-image-gallery-current-height            : 33.125rem;   // 530px
 
   // --------------------------------------------------------
   // Structural Styles
@@ -38,7 +38,7 @@
 
   @include media(">=notebook") {
     >[data-fs-image] {
-      max-height: var(--fs-image-gallery-current-max-height);
+      height: var(--fs-image-gallery-current-height);
     }
   }
 


### PR DESCRIPTION
## What's the purpose of this pull request?
Tiny PR to port some extra fixes we did on https://github.com/vtex-sites/gatsby.store/pull/205:
- Updates height values from `px` to `rem`
- Improves `ImageGallery` visibility on Storybook
- Fixes `ImageGallery` height on responsive views of the PDP

## How to test it?
Check PDP page variants on both desktop and mobile views:
- [with gallery selector](https://sfj-6162459--nextjs.preview.vtex.app/apple-magic-mouse-99988212/p)
- [without gallery selector](https://sfj-6162459--nextjs.preview.vtex.app/4k-philips-monitor-99988213/p)
- [Storybook Doc](https://nextjs-store-storybook-git-fix-image-gallery-height-faststore.vercel.app/?path=/docs/organisms-imagegallery--default-story)

## Checklist
**PR Title and Commit Messages**
- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`
- [x] Added the component, hook, or path name in-between backticks (\`\`) - *if applicable, e.g., `ComponentName` component, `useWindowDimensions` hook*

**Documentation**
- [x] PR description
- [x] Added to/Updated the Storybook - *if applicable*
