### PR TITLE
fix: collection pages facets

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@envelop/graphql-jit": "^1.1.1",
     "@envelop/parser-cache": "^2.2.0",
     "@envelop/validation-cache": "^2.2.0",
-    "@faststore/api": "^1.12.16",
+    "@faststore/api": "^1.12.17",
     "@faststore/graphql-utils": "^1.11.8",
     "@faststore/sdk": "^1.11.8",
     "@faststore/ui": "^1.12.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,10 +1445,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@faststore/api@^1.12.16":
-  version "1.12.16"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-1.12.16.tgz#72516a79901215d05873d03a03fdfcf5d896fc0d"
-  integrity sha512-S7JEJgNqQFAxoe4q+Mh24d8pAvx+XNQxQnThKVA2YSMedVOgGJ3ZUhGTycXZwZqAJVBtQl5OUr9a/tsykEyeCg==
+"@faststore/api@^1.12.17":
+  version "1.12.17"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-1.12.17.tgz#fad07e1ac222040873722eb709b393a6f2a8609f"
+  integrity sha512-l7tUpNM1pfNOACm69iWE5lNCl+JRVnJhFSYYo0QqD/KbHWtpXq9mQHK2cVX1VDWjADNXgWm4Nem7Fyyf/+dINQ==
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

More info at: https://github.com/vtex/faststore/pull/1477

## How does it work?

- Fix the search facets to use the productClusterIds when the pageType is Collection

## How to test it?

- ❌ Navigate to page: [https://nextjs.vtex.app/just-arrived](https://nextjs.vtex.app/just-arrived) and you will see that it returns no search result
- ✅ Navigate to page: [https://sfj-2a1cff2--nextjs.preview.vtex.app/just-arrived](https://sfj-2a1cff2--nextjs.preview.vtex.app/just-arrived) and you will see that it works

## References

<em>Spread the knowledge: is this any content you used to create this PR that is worth sharing?</em>

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em>
