### PR TITLE
fix: using data-fs instead data-store

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@faststore/api": "^1.12.8",
     "@faststore/graphql-utils": "^1.10.34",
     "@faststore/sdk": "^1.10.34",
-    "@faststore/ui": "https://pkg.csb.dev/vtex/faststore/commit/adf155b3/@faststore/ui",
+    "@faststore/ui": "^1.12.11",
     "@vtex/client-cms": "^0.2.10",
     "graphql": "^15.0.0",
     "include-media": "^1.4.10",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@faststore/api": "^1.12.8",
     "@faststore/graphql-utils": "^1.10.34",
     "@faststore/sdk": "^1.10.34",
-    "@faststore/ui": "https://pkg.csb.dev/vtex/faststore/commit/2d5e5576/@faststore/ui",
+    "@faststore/ui": "https://pkg.csb.dev/vtex/faststore/commit/adf155b3/@faststore/ui",
     "@vtex/client-cms": "^0.2.10",
     "graphql": "^15.0.0",
     "include-media": "^1.4.10",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@faststore/api": "^1.12.8",
     "@faststore/graphql-utils": "^1.10.34",
     "@faststore/sdk": "^1.10.34",
-    "@faststore/ui": "^1.12.5",
+    "@faststore/ui": "https://pkg.csb.dev/vtex/faststore/commit/2d5e5576/@faststore/ui",
     "@vtex/client-cms": "^0.2.10",
     "graphql": "^15.0.0",
     "include-media": "^1.4.10",

--- a/src/components/common/Footer/footer.module.scss
+++ b/src/components/common/Footer/footer.module.scss
@@ -132,7 +132,7 @@
       padding: var(--fs-footer-spacing-vertical-mobile) 0 var(--fs-spacing-3);
     }
 
-    [data-store-list] {
+    [data-fs-list] {
       display: flex;
       justify-content: center;
 
@@ -161,7 +161,7 @@
     }
   }
 
-  [data-store-icon] {
+  [data-fs-icon] {
     @include media(">=notebook") {
       grid-column: span 2;
     }
@@ -173,7 +173,7 @@
       border-radius: var(--fs-footer-payment-methods-flags-border-radius);
     }
 
-    [data-store-list] {
+    [data-fs-list] {
       display: grid;
       grid-template-columns: repeat(4, minmax(0, max-content));
       row-gap: var(--fs-spacing-1);

--- a/src/components/common/Navbar/navbar.module.scss
+++ b/src/components/common/Navbar/navbar.module.scss
@@ -142,7 +142,7 @@
           }
         }
 
-        [data-store-icon] {
+        [data-fs-icon] {
           margin-right: 0;
           line-height: 0;
 
@@ -166,7 +166,7 @@
           width: var(--fs-navbar-search-expanded-input-width);
         }
 
-        [data-store-icon] {
+        [data-fs-icon] {
           margin-right: 0;
         }
       }

--- a/src/components/product/OutOfStock/OutOfStock.tsx
+++ b/src/components/product/OutOfStock/OutOfStock.tsx
@@ -118,7 +118,7 @@ function OutOfStock(props: OutOfStockProps) {
         }}
       />
       <Button
-        data-store-out-of-stock-button
+        data-fs-out-of-stock-button
         type="submit"
         disabled={disabled}
         variant="primary"

--- a/src/components/product/OutOfStock/out-of-stock.module.scss
+++ b/src/components/product/OutOfStock/out-of-stock.module.scss
@@ -50,7 +50,7 @@
     color: var(--fs-out-of-stock-message-color);
   }
 
-  [data-store-button] {
+  [data-fs-button] {
     width: var(--fs-out-of-stock-button-width);
     margin-top: var(--fs-out-of-stock-button-margin-top);
   }

--- a/src/components/product/ProductCard/product-card.module.scss
+++ b/src/components/product/ProductCard/product-card.module.scss
@@ -120,7 +120,7 @@
       }
     }
 
-    [data-store-badge],
+    [data-fs-badge],
     [data-fs-product-card-actions] { margin-top: var(--fs-spacing-2); }
   }
 
@@ -218,7 +218,7 @@
       border-radius: 0;
     }
 
-    [data-store-badge] {
+    [data-fs-badge] {
       @include media(">=notebook") {
         grid-row: 1;
         grid-column: 2;
@@ -242,7 +242,7 @@
       gap: calc(var(--fs-product-card-gap) / 2);
     }
 
-    [data-store-badge] { align-self: end; }
+    [data-fs-badge] { align-self: end; }
     [data-fs-product-card-prices] { margin-bottom: 0; }
   }
 }

--- a/src/components/search/Filter/Facets.tsx
+++ b/src/components/search/Filter/Facets.tsx
@@ -51,7 +51,7 @@ function Facets({
   onAccordionChange,
 }: FacetsProps) {
   return (
-    <div className={styles.fsFacets} data-store-filter data-testid={testId}>
+    <div className={styles.fsFacets} data-fs-filter data-testid={testId}>
       <h2 className="text__title-mini-alt" data-fs-facets-title>
         Filters
       </h2>

--- a/src/components/search/SearchInput/search-input.module.scss
+++ b/src/components/search/SearchInput/search-input.module.scss
@@ -58,7 +58,7 @@
 
   position: relative;
 
-  [data-store-search-input] {
+  [data-fs-search-input] {
     position: relative;
     display: inline-flex;
     width: 100%;
@@ -89,7 +89,7 @@
       }
     }
 
-    [data-store-button] {
+    [data-fs-button] {
       position: absolute;
       right: 0;
       width: var(--fs-search-input-button-width);
@@ -104,9 +104,9 @@
       }
     }
 
-    [data-store-icon] { display: block; }
+    [data-fs-icon] { display: block; }
 
-    [data-store-button] svg {
+    [data-fs-button] svg {
       width: var(--fs-search-input-icon-width);
       height: var(--fs-search-input-icon-height);
       color: var(--fs-search-input-icon-color);

--- a/src/components/sections/Incentives/incentives.module.scss
+++ b/src/components/sections/Incentives/incentives.module.scss
@@ -38,7 +38,7 @@
   padding-top: var(--fs-incentives-padding-top);
   padding-bottom: var(--fs-incentives-padding-bottom);
 
-  [data-store-list] {
+  [data-fs-list] {
     display: flex;
     width: fit-content;
     overflow-x: auto;
@@ -49,7 +49,7 @@
     }
   }
 
-  [data-store-incentive] {
+  [data-fs-incentive] {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/sections/ProducDetailsContent/product-details-content.module.scss
+++ b/src/components/sections/ProducDetailsContent/product-details-content.module.scss
@@ -5,7 +5,7 @@
   // List
   // -----------------------------
 
-  [data-fs-product-details-highlights] [data-store-list="unordered"] {
+  [data-fs-product-details-highlights] [data-fs-list="unordered"] {
     list-style: initial;
     list-style-position: inside;
   }
@@ -14,14 +14,14 @@
   // Table
   // -----------------------------
 
-  [data-fs-product-details-about] [data-store-table] {
+  [data-fs-product-details-about] [data-fs-table] {
     width: 100%;
 
     [data-fs-accordion-item-button-icon] {
       height: 18px;
     }
 
-    [data-store-icon] {
+    [data-fs-icon] {
       margin-right: var(--fs-spacing-2);
     }
 

--- a/src/components/sections/ProductDetails/product-details.module.scss
+++ b/src/components/sections/ProductDetails/product-details.module.scss
@@ -39,7 +39,7 @@
   [data-fs-product-details-section] {
     height: fit-content;
 
-    [data-store-sku-selector] {
+    [data-fs-sku-selector] {
       margin-bottom: var(--fs-product-details-vertical-spacing);
       &:last-of-type { margin-bottom: var(--fs-spacing-7); }
     }

--- a/src/components/sections/ProductGallery/product-gallery.module.scss
+++ b/src/components/sections/ProductGallery/product-gallery.module.scss
@@ -165,7 +165,7 @@
       padding: var(--fs-spacing-1) var(--fs-spacing-2);
     }
 
-    [data-store-button] {
+    [data-fs-button] {
       width: 100%;
 
       @include media(">=notebook") {

--- a/src/components/ui/Alert/alert.module.scss
+++ b/src/components/ui/Alert/alert.module.scss
@@ -35,7 +35,7 @@
   color: var(--fs-alert-text-color);
   background-color: var(--fs-alert-bkg-color);
 
-  [data-store-icon] {
+  [data-fs-icon] {
     padding-right: var(--fs-spacing-1);
     margin: 0;
   }

--- a/src/components/ui/Button/button.module.scss
+++ b/src/components/ui/Button/button.module.scss
@@ -137,7 +137,7 @@
   box-shadow: var(--fs-button-shadow);
   transition: var(--fs-button-transition-property) var(--fs-button-transition-timing) var(--fs-button-transition-function);
 
-  [data-store-icon] {
+  [data-fs-icon] {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/components/ui/InputText/input-text.module.scss
+++ b/src/components/ui/InputText/input-text.module.scss
@@ -159,7 +159,7 @@
       }
     }
 
-    [data-fs-button][data-store-icon-button] {
+    [data-fs-button][data-fs-icon-button] {
       &::before {
         left: calc(-1 * var(--fs-spacing-1));
       }

--- a/src/components/ui/PriceRange/price-range.module.scss
+++ b/src/components/ui/PriceRange/price-range.module.scss
@@ -38,7 +38,7 @@
   // Structural Styles
   // --------------------------------------------------------
 
-  [data-store-slider] {
+  [data-fs-slider] {
     position: relative;
     width: 100%;
     height: var(--fs-price-range-height);

--- a/src/components/ui/ProductTitle/product-title.module.scss
+++ b/src/components/ui/ProductTitle/product-title.module.scss
@@ -31,7 +31,7 @@
       line-height: var(--fs-product-title-line-height);
     }
 
-    [data-store-badge] { white-space: nowrap; }
+    [data-fs-badge] { white-space: nowrap; }
 
     @include media(">=tablet", "<notebook") {
       flex-direction: column;

--- a/src/components/ui/QuantitySelector/quantity-selector.module.scss
+++ b/src/components/ui/QuantitySelector/quantity-selector.module.scss
@@ -60,7 +60,7 @@
   border-radius: var(--fs-qty-selector-border-radius);
   box-shadow: var(--fs-qty-selector-shadow);
 
-  [data-store-icon] {
+  [data-fs-icon] {
     margin: 0;
     line-height: 0;
     color: var(--fs-qty-selector-icon-color);
@@ -94,7 +94,7 @@
     border: 0;
     border-radius: var(--fs-qty-selector-button-border-radius);
 
-    [data-store-icon] {
+    [data-fs-icon] {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -112,7 +112,7 @@
 
     &:last-of-type { right: 0; }
 
-    &:hover:not(:disabled) [data-store-icon] {
+    &:hover:not(:disabled) [data-fs-icon] {
       background-color: var(--fs-qty-selector-button-bkg-color-hover);
       box-shadow: var(--fs-qty-selector-button-shadow-hover);
     }
@@ -120,7 +120,7 @@
     &:disabled {
       cursor: not-allowed;
 
-      [data-store-icon] {
+      [data-fs-icon] {
         color: var(--fs-qty-selector-disabled-icon-color);
       }
     }
@@ -128,7 +128,7 @@
     &:focus-visible {
       outline: none;
 
-      [data-store-icon] {
+      [data-fs-icon] {
         @include focus-ring;
 
         background-color: var(--fs-qty-selector-button-bkg-color-focus);
@@ -155,6 +155,6 @@
       background-color: var(--fs-qty-selector-disabled-bkg-color);
       border-color: var(--fs-qty-selector-disabled-border-color);
     }
-    [data-quantity-selector-button]:hover [data-store-icon] { background-color: transparent; }
+    [data-quantity-selector-button]:hover [data-fs-icon] { background-color: transparent; }
   }
 }

--- a/src/components/ui/SROnly/SROnly.tsx
+++ b/src/components/ui/SROnly/SROnly.tsx
@@ -8,7 +8,7 @@ interface Props {
 function SROnly({ text, as }: Props) {
   const Component = as ?? 'span'
 
-  return <Component data-store-sr-only>{text}</Component>
+  return <Component data-fs-sr-only>{text}</Component>
 }
 
 export default SROnly

--- a/src/components/ui/SROnly/sr-only.scss
+++ b/src/components/ui/SROnly/sr-only.scss
@@ -1,4 +1,4 @@
-[data-store-sr-only]:not(:focus):not(:active) {
+[data-fs-sr-only]:not(:focus):not(:active) {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/src/components/ui/SkuSelector/sku-selector.module.scss
+++ b/src/components/ui/SkuSelector/sku-selector.module.scss
@@ -80,7 +80,7 @@
     margin-bottom: var(--fs-sku-selector-title-margin-bottom);
   }
 
-  [data-store-radio-option] {
+  [data-fs-radio-option] {
     position: relative;
     width: var(--fs-sku-selector-option-width);
     height: var(--fs-sku-selector-option-height);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,19 +1479,18 @@
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^1.12.5":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/2d5e5576/@faststore/ui":
   version "1.12.5"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-1.12.5.tgz#596891b0cf431cac750c5927c932538de866f410"
-  integrity sha512-OVqXPVcRO+a8w/GbIXScK/Sy7XTx3PEc6tS426RxI/t22OmSoYGMvu2vKuavcbtzuzEd9u7NdushPreMbQS+Zw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/2d5e5576/@faststore/ui#5fca589e45741c7524ff4e1acce78ce5f67f9271"
   dependencies:
     "@reach/popover" "^0.16.0"
     "@storybook/addon-a11y" "^6.4.4"
     react-swipeable "^6.1.2"
     tabbable "^5.2.1"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/2d5e5576/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/adf155b3/@faststore/ui":
   version "1.12.5"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/2d5e5576/@faststore/ui#5fca589e45741c7524ff4e1acce78ce5f67f9271"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/adf155b3/@faststore/ui#0537dade7876689d130dbeb93d1db0bd7d6bc5c3"
   dependencies:
     "@reach/popover" "^0.16.0"
     "@storybook/addon-a11y" "^6.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,6 +1489,15 @@
     react-swipeable "^6.1.2"
     tabbable "^5.2.1"
 
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/2d5e5576/@faststore/ui":
+  version "1.12.5"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/2d5e5576/@faststore/ui#5fca589e45741c7524ff4e1acce78ce5f67f9271"
+  dependencies:
+    "@reach/popover" "^0.16.0"
+    "@storybook/addon-a11y" "^6.4.4"
+    react-swipeable "^6.1.2"
+    tabbable "^5.2.1"
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,18 +1479,10 @@
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/2d5e5576/@faststore/ui":
-  version "1.12.5"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/2d5e5576/@faststore/ui#5fca589e45741c7524ff4e1acce78ce5f67f9271"
-  dependencies:
-    "@reach/popover" "^0.16.0"
-    "@storybook/addon-a11y" "^6.4.4"
-    react-swipeable "^6.1.2"
-    tabbable "^5.2.1"
-
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/adf155b3/@faststore/ui":
-  version "1.12.5"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/adf155b3/@faststore/ui#0537dade7876689d130dbeb93d1db0bd7d6bc5c3"
+"@faststore/ui@^1.12.11":
+  version "1.12.11"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-1.12.11.tgz#9649840b664c0e4dc4b6942bfc5038df77863e02"
+  integrity sha512-1qLxsekcBe3mSTPV4Wdr5kUeMJJll1FuZplxBFAEPBMoF6ySP+xZp6JyWIVeW7w+5gU9uObXkbhfZpNHAW0eKQ==
   dependencies:
     "@reach/popover" "^0.16.0"
     "@storybook/addon-a11y" "^6.4.4"


### PR DESCRIPTION
## What's the purpose of this pull request?

In order to use https://github.com/vtex/faststore/pull/1482 I decided to rename the `data-store` to `data-fs`.

## How does it work?

All data-store attributes are renamed to data-fs.

## How to test it?

<em>Describe the steps with bullet points. Is there any external reference, link, or example?</em>

## References

<em>Spread the knowledge: is any content you used to create this PR worth sharing?</em>

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em>

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**
- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`
- [ ] Added the component, hook, or path name in-between backticks (\`\`) - *if applicable, e.g., `ComponentName` component, `useWindowDimensions` hook*

**Dependencies**
- [ ] Committed the `yarn.lock` and `bun.lockb` file when there were changes to the packages

**Documentation**
- [ ] PR description
- [ ] Added to/Updated the Storybook - *if applicable*
- [ ] For documentation changes, ping `@carolinamenezes` or `@PedroAntunesCosta` to review and update
