### PR TITLE
Feat: Removes content visibility

### DIFF
--- a/src/components/common/Footer/Footer.stories.mdx
+++ b/src/components/common/Footer/Footer.stories.mdx
@@ -50,9 +50,6 @@ Footer section is made with `FooterLinks`, [Incentives](?path=/docs/organisms-in
 <ArgsTable story="Footer" />
 
 <TokenTable>
-  <TokenRow token="--fs-footer-min-height-mobile" value="rem(860px)" />
-  <TokenRow token="--fs-footer-min-height-notebook" value="rem(486px)" />
-  <TokenDivider />
   <TokenRow
     token="--fs-footer-spacing-vertical-mobile"
     value="var(--fs-spacing-4)"

--- a/src/components/common/Footer/footer.module.scss
+++ b/src/components/common/Footer/footer.module.scss
@@ -6,9 +6,6 @@
   // --------------------------------------------------------
 
   // Default properties
-  --fs-footer-min-height-mobile                   : rem(860px);
-  --fs-footer-min-height-notebook                 : rem(486px);
-
   --fs-footer-spacing-vertical-mobile             : var(--fs-spacing-4);
   --fs-footer-spacing-vertical-notebook           : var(--fs-spacing-5);
   --fs-footer-spacing-horizontal-notebook         : var(--fs-grid-gap-3);
@@ -36,16 +33,10 @@
 
   &[data-fs-footer] {
     background-color: var(--fs-footer-bkg-color);
-    content-visibility: auto;
-    contain-intrinsic-size: var(--fs-footer-min-height-mobile);
   }
 
   @include media("<notebook") {
     padding-top: 0;
-  }
-
-  @include media(">=notebook") {
-    contain-intrinsic-size: var(--fs-footer-min-height-notebook);
   }
 
   [data-fs-logo] {

--- a/src/components/sections/Section/section.scss
+++ b/src/components/sections/Section/section.scss
@@ -2,8 +2,6 @@
 
 .section {
   width: 100%;
-  content-visibility: auto;
-  contain-intrinsic-size: rem(2px) rem(1024px);
 
   .text__title-section {
     margin-bottom: var(--fs-spacing-3);


### PR DESCRIPTION
## What's the purpose of this pull request?

Solves the scroll-locking behavior.
|Previous|After|
|-|-|
|https://user-images.githubusercontent.com/11325562/194408866-e7870691-8eb5-470d-a8a6-11fbdfa3ec80.mp4|![after](https://user-images.githubusercontent.com/11325562/194409860-036a1985-796a-48de-b067-aaad8b9ef244.gif)|

## How does it work?

Removes the `content-visibility` related style from `section.scss` and `footer.scss`.

## How to test it?

you can compare the preview link and the one from the https://nextjs.vtex.app/

## References

https://web.dev/content-visibility/.
https://github.com/vtex-sites/base.store/pull/368