### PR TITLE
chore: Change `resource-summary:stylesheet` metric to warning

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -17,5 +17,6 @@ module.exports = lhConfig({
       },
     ],
     deprecations: 'warn',
+    'resource-summary:stylesheet:count': ['warn', { maxNumericValue: 400 }],
   },
 })


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to change how Lighthouse treats the `resource-summary:stylesheet` metric (from error to warning). Also, the max numeric value for it was increased.

## How does it work?

No code changes were applied.

## References

- [Web.dev Resource summary](https://web.dev/resource-summary/)

## Checklist

**PR Title and Commit Messages**
- [x] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [x] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`

**Documentation**
- [x] PR description