### PR TITLE
feat: Add Page content-type

### DIFF
--- a/cms/content-types.json
+++ b/cms/content-types.json
@@ -5,8 +5,48 @@
     "configurationSchemaSets": []
   },
   {
-    "id": "home",
-    "name": "Home Page",
-    "configurationSchemaSets": []
+    "id": "page",
+    "name": "Page",
+    "configurationSchemaSets": [
+      {
+        "name": "Settings",
+        "configurations": [
+          {
+            "name": "seo",
+            "schema": {
+              "title": "SEO",
+              "description": "Search Engine Optimization options",
+              "type": "object",
+              "widget": {
+                "ui:ObjectFieldTemplate": "GoogleSeoPreview"
+              },
+              "required": ["slug", "title", "description"],
+              "properties": {
+                "slug": {
+                  "title": "Path",
+                  "type": "string",
+                  "default": "/"
+                },
+                "title": {
+                  "title": "Default page title",
+                  "description": "Display this title when no other tile is available",
+                  "type": "string",
+                  "default": "FastStore"
+                },
+                "description": {
+                  "title": "Meta tag description",
+                  "type": "string",
+                  "default": "A beautifuly designed store"
+                },
+                "canonical": {
+                  "title": "Canonical url for the page",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/cms/sections.json
+++ b/cms/sections.json
@@ -327,5 +327,24 @@
         }
       }
     }
+  },
+  {
+    "name": "Newsletter",
+    "schema": {
+      "title": "Newsletter",
+      "description": "Allow users to subscribe to your updates",
+      "type": "object",
+      "required": ["title"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description"
+        }
+      }
+    }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@faststore/graphql-utils": "^1.11.8",
     "@faststore/sdk": "^1.11.8",
     "@faststore/ui": "^1.12.13",
-    "@vtex/client-cms": "^0.2.10",
+    "@vtex/client-cms": "^0.2.12",
     "graphql": "^15.0.0",
     "include-media": "^1.4.10",
     "next": "^12.3.1",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,32 +1,30 @@
 import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
 import type { GetStaticProps } from 'next'
-import type { ContentData, Locator } from '@vtex/client-cms'
+import type { Locator } from '@vtex/client-cms'
 
 import RenderPageSections from 'src/components/cms/RenderPageSections'
-import Newsletter from 'src/components/sections/Newsletter'
+import type { PageContentType } from 'src/server/cms'
+import { getPage } from 'src/server/cms'
 import { mark } from 'src/sdk/tests/mark'
-import { getPageSections } from 'src/server/cms'
 
 import storeConfig from '../../store.config'
 
-interface Props {
-  sections: ContentData['sections']
-}
+type Props = PageContentType
 
-function Page({ sections }: Props) {
+function Page({ sections, settings }: Props) {
   return (
     <>
       {/* SEO */}
       <NextSeo
-        title={storeConfig.seo.title}
-        description={storeConfig.seo.description}
+        title={settings.seo.title}
+        description={settings.seo.description}
         titleTemplate={storeConfig.seo.titleTemplate}
-        canonical={storeConfig.storeUrl}
+        canonical={settings.seo.canonical ?? storeConfig.storeUrl}
         openGraph={{
           type: 'website',
           url: storeConfig.storeUrl,
-          title: storeConfig.seo.title,
-          description: storeConfig.seo.description,
+          title: settings.seo.title,
+          description: settings.seo.description,
         }}
       />
       <SiteLinksSearchBoxJsonLd
@@ -51,10 +49,6 @@ function Page({ sections }: Props) {
         (not the HTML tag) before rendering it here.
       */}
       <RenderPageSections sections={sections} />
-      <Newsletter
-        title="Get News and Special Offers!"
-        description="Receive our news and promotions in advance. Enjoy and get 10% off your first purchase. For more information click here."
-      />
     </>
   )
 }
@@ -64,12 +58,13 @@ export const getStaticProps: GetStaticProps<
   Record<string, string>,
   Locator
 > = async (context) => {
-  const sections = await getPageSections(context.previewData ?? 'home')
+  const page = await getPage<PageContentType>({
+    ...(context.previewData ?? { filters: { 'settings.seo.slug': '/' } }),
+    contentType: 'page',
+  })
 
   return {
-    props: {
-      sections: sections ?? [],
-    },
+    props: page,
   }
 }
 

--- a/src/server/cms.ts
+++ b/src/server/cms.ts
@@ -20,14 +20,38 @@ const isLocator = (x: any): x is Locator =>
   typeof x.contentType === 'string' &&
   (typeof x.releaseId === 'string' || typeof x.documentId === 'string')
 
-export const getPage = <T extends ContentData>(options: Options) => {
-  const page = isLocator(options)
-    ? clientCMS.getCMSPage(options)
-    : clientCMS
-        .getCMSPagesByContentType(options.contentType, options.filters)
-        .then((pages) => pages.data[0])
+export const getPage = async <T extends ContentData>(options: Options) => {
+  const result = await (isLocator(options)
+    ? clientCMS.getCMSPage(options).then((page) => ({ data: [page] }))
+    : clientCMS.getCMSPagesByContentType(options.contentType, options.filters))
 
-  return page as Promise<T>
+  const pages = result.data
+
+  if (!pages[0]) {
+    throw new Error(
+      `Missing content on the CMS for content type ${
+        options.contentType
+      }. Add content before proceeding. Context: ${JSON.stringify(
+        options,
+        null,
+        2
+      )}`
+    )
+  }
+
+  if (pages.length !== 1) {
+    throw new Error(
+      `Multiple content defined on the CMS for content type ${
+        options.contentType
+      }. Remove duplicated content before proceeding. Context: ${JSON.stringify(
+        options,
+        null,
+        2
+      )}`
+    )
+  }
+
+  return pages[0] as T
 }
 
 export type PageContentType = ContentData & {

--- a/src/server/cms.ts
+++ b/src/server/cms.ts
@@ -36,8 +36,7 @@ export type PageContentType = ContentData & {
       slug: string
       title: string
       description: string
-      titleTemplate: string
-      canonical: string
+      canonical?: string
     }
   }
 }

--- a/src/server/cms.ts
+++ b/src/server/cms.ts
@@ -17,7 +17,7 @@ type Options =
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isLocator = (x: any): x is Locator =>
-  typeof x.documentId === 'string' &&
+  typeof x.contentType === 'string' &&
   (typeof x.releaseId === 'string' || typeof x.documentId === 'string')
 
 export const getPage = <T extends ContentData>(options: Options) => {

--- a/store.config.js
+++ b/store.config.js
@@ -15,7 +15,7 @@ module.exports = {
   // Platform specific configs for API
   api: {
     storeId: 'storeframework',
-    workspace: 'gimenes',
+    workspace: 'master',
     environment: 'vtexcommercestable',
     hideUnavailableItems: true,
   },

--- a/store.config.js
+++ b/store.config.js
@@ -15,7 +15,7 @@ module.exports = {
   // Platform specific configs for API
   api: {
     storeId: 'storeframework',
-    workspace: 'master',
+    workspace: 'gimenes',
     environment: 'vtexcommercestable',
     hideUnavailableItems: true,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3919,10 +3919,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@vtex/client-cms@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@vtex/client-cms/-/client-cms-0.2.10.tgz#d2e3dee0b9a38b0ee3de3e4cec0d31349f4c8cf5"
-  integrity sha512-z9pg0srPxdL5lZ+tgWsnYvsHm2IcNEOukVnjJ1+8GqWDFiaJkPskuJhhuJhA7cAa4pLpDUONYnDlALT1BTNnFg==
+"@vtex/client-cms@^0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@vtex/client-cms/-/client-cms-0.2.12.tgz#c75777ff3cfa37e1d9904074b9b0fa63f93f081e"
+  integrity sha512-Eg5AWsWZzz8ddhSnpI4dQrXzsf+DUbfxERbiKS5mssb/nlBEXoVAeabWzlJrkMjdHQiQn7BSllNLeocoRkXJBA==
   dependencies:
     fetch-retry "^4.1.1"
     isomorphic-unfetch "^3.1.0"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR does two things:
1. Add Newsletter component to CMS sections
2. Refactor Home to Page content type

`1` is pretty straight forward, however I still think this component should be refactored to be more CMS friendly (there are some texts that are not modifiable), but this can be done on a later PR

`2` will fulfill that vision that users may enter on the CMS, create a new "page" and configure a new institutional page, landing page etc. Turns out that the home page can be represented as one of those pages. 

## How does it work?
Home content type was deleted and a Page was added. This new content type has a `settings` section where the user must enter infos like: `slug`, `title`, `description` and `canonical` page. If the canonical is not filled, it's inferred from store.config.json. The final CMS screen looks like:

![image](https://user-images.githubusercontent.com/1753396/196511543-23be3319-2480-4abb-ad1b-8462f27c6bab.png)

Sections behavior are keep between Home and Page content type

Also, to make it possible fetching content by the slug, the `@vtex/client-cms` was updated. To filter contents by an attribute one can:
```
const page = await getPage<PageContentType>({
    filters: { 'settings.seo.slug': '/' },
    contentType: 'page',
  })
```

this will filter the property at the path `settings.seo.slug` by value `/`. If more than one content is match, the first one is returned. This may lead to inconsistencies.

## Future work
Future PRs may join this `page` content-type with the `[...slug].tsx` file. This, alongside incoming Next.JS features, will finally allow different pages creation, set banners on plps etc.

## How to test it?
Nothing should have changed from previous releases