### PR TITLE
Feat: CMS layout components

### DIFF
--- a/cms/content-types.json
+++ b/cms/content-types.json
@@ -1,7 +1,7 @@
 [
   {
-    "id": "globalAlert",
-    "name": "Global Alert Page",
+    "id": "layout",
+    "name": "Global Components",
     "configurationSchemaSets": []
   },
   {

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -17,7 +17,7 @@ const RegionModal = lazy(
 function Layout({ children }: PropsWithChildren) {
   const { cart: displayCart, modal: displayModal } = useUI()
 
-  const options = useMemo(() => ({ contentType: 'globalAlert' }), [])
+  const options = useMemo(() => ({ contentType: 'layout' }), [])
   const page = useCMS(options)
 
   return (

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,7 +1,8 @@
-import { lazy, Suspense } from 'react'
 import type { PropsWithChildren } from 'react'
+import { lazy, Suspense, useMemo } from 'react'
 
-import Alert from 'src/components/common/Alert'
+import RenderLayoutSections from 'src/components/cms/RenderLayoutSections'
+import { useCMS } from 'src/components/cms/useCMS'
 import Footer from 'src/components/common/Footer'
 import Navbar from 'src/components/common/Navbar'
 import Toast from 'src/components/common/Toast'
@@ -16,11 +17,12 @@ const RegionModal = lazy(
 function Layout({ children }: PropsWithChildren) {
   const { cart: displayCart, modal: displayModal } = useUI()
 
+  const options = useMemo(() => ({ contentType: 'globalAlert' }), [])
+  const page = useCMS(options)
+
   return (
     <>
-      <Alert icon="Bell" link={{ text: 'Buy now', to: '/office' }} dismissible>
-        Get 10% off today:&nbsp;<span>NEW10</span>
-      </Alert>
+      <RenderLayoutSections sections={page?.sections} />
 
       <Navbar />
 

--- a/src/components/cms/RenderLayoutSections.tsx
+++ b/src/components/cms/RenderLayoutSections.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { ComponentType } from 'react'
+
+import Alert from 'src/components/common/Alert'
+
+import SectionBoundary from './SectionBoundary'
+
+/**
+ * Sections: Components imported from '../components/common' only.
+ * Do not import or render components from any other folder in here.
+ */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  Alert,
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+// prevent Cumulative Layout Shift (CLS)
+const fallbackSessions: Array<{ name: string; data: any }> = [
+  {
+    name: 'Alert',
+    data: {
+      link: {
+        text: 'Buy now',
+        to: '/office',
+      },
+      dismissible: true,
+      icon: 'Bell',
+      content: 'Get 10% off today',
+    },
+  },
+]
+
+interface Props {
+  sections?: Array<{ name: string; data: any }>
+}
+
+const RenderLayoutSections = ({ sections = fallbackSessions }: Props) => (
+  <>
+    {sections?.map(({ name, data }, index) => {
+      const Component = COMPONENTS[name]
+
+      if (!Component) {
+        console.info(
+          `Could not find component for block ${name}. Add a new component for this block or remove it from the CMS`
+        )
+
+        return <></>
+      }
+
+      return (
+        <SectionBoundary key={`cms-layout-section-${index}`} name={name}>
+          <Component {...data} />
+        </SectionBoundary>
+      )
+    })}
+  </>
+)
+
+export default RenderLayoutSections

--- a/src/components/cms/useCMS.tsx
+++ b/src/components/cms/useCMS.tsx
@@ -1,0 +1,22 @@
+import type { ContentData } from '@vtex/client-cms'
+import { useEffect, useMemo, useState } from 'react'
+
+import type { Options } from 'src/server/cms'
+import { fetchCMS } from 'src/server/cms'
+
+export const useCMS = (options: Options) => {
+  const [page, setPage] = useState<ContentData>()
+
+  useEffect(() => {
+    const fetchCMSPage = async () => {
+      const result = await fetchCMS(options)
+      const pageResult = await result.json()
+
+      setPage(pageResult)
+    }
+
+    fetchCMSPage()
+  }, [options])
+
+  return useMemo(() => page, [page])
+}

--- a/src/pages/api/cms.ts
+++ b/src/pages/api/cms.ts
@@ -21,14 +21,6 @@ const handler: NextApiHandler = async (req, res) => {
       contentType: pickParam(req, 'contentType'),
     })
 
-    // If the content doesn't exist prevent preview mode from being enabled
-    if (!page) {
-      throw new StatusError(
-        `Content NotFound for ${JSON.stringify(req.query, null, 2)}`,
-        404
-      )
-    }
-
     res.status(200).json(page)
   } catch (error) {
     if (error instanceof StatusError) {

--- a/src/pages/api/cms.ts
+++ b/src/pages/api/cms.ts
@@ -1,0 +1,44 @@
+import type { ContentData } from '@vtex/client-cms'
+import type { NextApiHandler } from 'next'
+
+import { getPage } from 'src/server/cms'
+
+import { pickParam } from './preview'
+
+class StatusError extends Error {
+  constructor(message: string, public status: number) {
+    super(message)
+  }
+}
+
+const handler: NextApiHandler = async (req, res) => {
+  try {
+    if (req.method !== 'GET') {
+      throw new StatusError(`Only GET requests allowed`, 405)
+    }
+
+    const page = await getPage<ContentData>({
+      contentType: pickParam(req, 'contentType'),
+    })
+
+    // If the content doesn't exist prevent preview mode from being enabled
+    if (!page) {
+      throw new StatusError(
+        `Content NotFound for ${JSON.stringify(req.query, null, 2)}`,
+        404
+      )
+    }
+
+    res.status(200).json(page)
+  } catch (error) {
+    if (error instanceof StatusError) {
+      res.status(error.status).end(error.message)
+
+      return
+    }
+
+    throw error
+  }
+}
+
+export default handler

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -8,7 +8,7 @@ class StatusError extends Error {
   }
 }
 
-const pickParam = (req: NextApiRequest, parameter: string) => {
+export const pickParam = (req: NextApiRequest, parameter: string) => {
   const maybeParam = req.query[parameter]
 
   if (typeof maybeParam !== 'string') {

--- a/src/server/cms.ts
+++ b/src/server/cms.ts
@@ -1,5 +1,5 @@
 import ClientCMS from '@vtex/client-cms'
-import type { Locator, ContentData } from '@vtex/client-cms'
+import type { ContentData, Locator } from '@vtex/client-cms'
 
 import config from '../../store.config'
 
@@ -8,7 +8,7 @@ export const clientCMS = new ClientCMS({
   tenant: config.api.storeId,
 })
 
-type Options =
+export type Options =
   | Locator
   | {
       contentType: string
@@ -63,4 +63,10 @@ export type PageContentType = ContentData & {
       canonical?: string
     }
   }
+}
+
+export const fetchCMS = async (options: Options) => {
+  return fetch(
+    `/api/cms?${new URLSearchParams(Object.entries(options)).toString()}`
+  )
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR aims to deal with global components that we include in the `Layout` component. Here we just add the `Alert` for test purposes.

## How does it work?

First, we can't get the CMS data from the CMS [using getStaticProps](https://nextjs.org/docs/basic-features/layouts#data-fetching:~:text=a%20Page%2C-,you%20cannot%20use,-getStaticProps%20or%20getServerSideProps) inside the `Layout` component, only in pages. Thus, we need to get the CMS data using the client side.

Then, the new `useCMS` hook was created that aims to get the CMS data using the new endpoint `api/cms`. That's because we can't use the `getPage` method from the `src/server/cms.ts` for the sake of `CORS` errors.

We also created the `RenderLayoutSections` component. So that we can render only the Layout (Global Components) over there. The code looks similar to the `RenderPageSections` but with the `Alert` component `fallback` so that we can prevent the Cumulative Layout Shift (CLS). At this moment I prefer to keep these 2 different components, but we can merge them and use only one if it looks better.

Finally, we sync the CMS `content-types.json` with:

```json
{
    "id": "layout",
    "name": "Global Components",
    "configurationSchemaSets": []
  }
```

instead of 
```json
{
    "id": "globalAlert",
    "name": "Global Alert Page",
    "configurationSchemaSets": []
}
```

IMO, it's better to deal with all layout (global) components together and add each component as sections than deal with every global component as a single `content type` with its own `section`. We can discuss more.


## How to test it?

Change the Global Components (page) > Alert (section) inside the new CMS, and check if the content changed in the preview link.

## References

https://nextjs.org/docs/basic-features/layouts#data-fetching
https://nextjs.org/blog/layouts-rfc#data-fetching-in-layouts

