### PR TITLE
feat: Integrate CMS with PDP

### DIFF
--- a/cms/content-types.json
+++ b/cms/content-types.json
@@ -48,5 +48,10 @@
         ]
       }
     ]
+  },
+  {
+    "id": "pdp",
+    "name": "Product Page",
+    "configurationSchemaSets": []
   }
 ]

--- a/cms/sections.json
+++ b/cms/sections.json
@@ -250,6 +250,34 @@
     }
   },
   {
+    "name": "CrossSellingShelf",
+    "schema": {
+      "title": "Cross Selling Shelf",
+      "description": "Add cross selling product data to your users",
+      "type": "object",
+      "required": ["title", "first", "after", "sort"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "items": {
+          "type": "integer",
+          "title": "First",
+          "default": 5,
+          "description": "Number of items to display"
+        },
+        "kind": {
+          "title": "Kind",
+          "description": "Change cross selling types",
+          "default": "buy",
+          "enum": ["buy", "view"],
+          "enumNames": ["Who bought also bought", "Who saw also saw"]
+        }
+      }
+    }
+  },
+  {
     "name": "ProductTiles",
     "schema": {
       "title": "Product Tiles",
@@ -345,6 +373,25 @@
           "title": "Description"
         }
       }
+    }
+  },
+  {
+    "name": "BannerNewsletter",
+    "schema": {
+      "title": "Banner Newsletter",
+      "description": "Add newsletter with a banner",
+      "type": "object",
+      "required": [],
+      "properties": {}
+    }
+  },
+  {
+    "name": "ProductDetails",
+    "schema": {
+      "title": "Product Details",
+      "description": "Display product gallery with buy button and shipping",
+      "type": "object",
+      "properties": {}
     }
   }
 ]

--- a/cms/sections.json
+++ b/cms/sections.json
@@ -255,7 +255,7 @@
       "title": "Cross Selling Shelf",
       "description": "Add cross selling product data to your users",
       "type": "object",
-      "required": ["title", "first", "after", "sort"],
+      "required": ["title", "items", "kind"],
       "properties": {
         "title": {
           "type": "string",

--- a/src/components/cms/RenderPageSections.tsx
+++ b/src/components/cms/RenderPageSections.tsx
@@ -1,36 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { ComponentType } from 'react'
 
-import BannerText from 'src/components/sections/BannerText'
-import Hero from 'src/components/sections/Hero'
-import IncentivesHeader from 'src/components/sections/Incentives/IncentivesHeader'
-import ProductShelf from 'src/components/sections/ProductShelf'
-import ProductTiles from 'src/components/sections/ProductTiles'
-import Newsletter from 'src/components/sections/Newsletter'
-
 import SectionBoundary from './SectionBoundary'
 
-/**
- * Sections: Components imported from '../components/sections' only.
- * Do not import or render components from any other folder in here.
- */
-const COMPONENTS: Record<string, ComponentType<any>> = {
-  Hero,
-  BannerText,
-  IncentivesHeader,
-  ProductShelf,
-  ProductTiles,
-  Newsletter,
-}
-
 interface Props {
-  sections?: Array<{ name: string; data: any }>
+  components: Record<string, ComponentType<any>>
+  sections: Array<{ name: string; data: any }>
+  context?: unknown
 }
 
-const RenderPageSections = ({ sections }: Props) => (
+const RenderPageSections = ({ sections = [], context, components }: Props) => (
   <>
-    {sections?.map(({ name, data }, index) => {
-      const Component = COMPONENTS[name]
+    {sections.map(({ name, data }, index) => {
+      const Component = components[name]
 
       if (!Component) {
         console.info(
@@ -42,7 +24,7 @@ const RenderPageSections = ({ sections }: Props) => (
 
       return (
         <SectionBoundary key={`cms-section-${index}`} name={name}>
-          <Component {...data} />
+          <Component {...data} context={context} />
         </SectionBoundary>
       )
     })}

--- a/src/components/sections/CrossSellingShelf/CrossSellingShelf.tsx
+++ b/src/components/sections/CrossSellingShelf/CrossSellingShelf.tsx
@@ -1,0 +1,25 @@
+import { useMemo } from 'react'
+
+import type { ProductDetailsFragment_ProductFragment } from '@generated/graphql'
+
+import ProductShelf from '../ProductShelf'
+
+interface Props {
+  items: number
+  title: string
+  context: ProductDetailsFragment_ProductFragment
+  kind: 'buy' | 'view'
+}
+
+const CrossSellingShelf = ({ items, title, context, kind }: Props) => {
+  const selectedFacets = useMemo(
+    () => [{ key: kind, value: context.isVariantOf.productGroupID }],
+    [kind, context.isVariantOf.productGroupID]
+  )
+
+  return (
+    <ProductShelf first={items} title={title} selectedFacets={selectedFacets} />
+  )
+}
+
+export default CrossSellingShelf

--- a/src/components/sections/CrossSellingShelf/index.tsx
+++ b/src/components/sections/CrossSellingShelf/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './CrossSellingShelf'

--- a/src/components/sections/ProductDetails/ProductDetails.tsx
+++ b/src/components/sections/ProductDetails/ProductDetails.tsx
@@ -25,10 +25,10 @@ import Section from '../Section'
 import ProductDetailsContent from '../ProducDetailsContent'
 
 interface Props {
-  product: ProductDetailsFragment_ProductFragment
+  context: ProductDetailsFragment_ProductFragment
 }
 
-function ProductDetails({ product: staleProduct }: Props) {
+function ProductDetails({ context: staleProduct }: Props) {
   const { currency } = useSession()
   const [addQuantity, setAddQuantity] = useState(1)
 

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -2,14 +2,18 @@ import { isNotFoundError } from '@faststore/api'
 import { gql } from '@faststore/graphql-utils'
 import { BreadcrumbJsonLd, NextSeo, ProductJsonLd } from 'next-seo'
 import type { GetStaticPaths, GetStaticProps } from 'next'
+import type { ComponentType } from 'react'
+import type { Locator } from '@vtex/client-cms'
 
-import ProductDetails from 'src/components/sections/ProductDetails'
-import ProductShelf from 'src/components/sections/ProductShelf'
+import RenderPageSections from 'src/components/cms/RenderPageSections'
 import BannerNewsletter from 'src/components/sections/BannerNewsletter/BannerNewsletter'
-import { ITEMS_PER_SECTION } from 'src/constants'
+import CrossSellingShelf from 'src/components/sections/CrossSellingShelf'
+import ProductDetails from 'src/components/sections/ProductDetails'
 import { useSession } from 'src/sdk/session'
 import { mark } from 'src/sdk/tests/mark'
 import { execute } from 'src/server'
+import { getPage } from 'src/server/cms'
+import type { PDPContentType } from 'src/server/cms'
 import type {
   ServerProductPageQueryQuery,
   ServerProductPageQueryQueryVariables,
@@ -17,9 +21,19 @@ import type {
 
 import storeConfig from '../../../store.config'
 
-type Props = ServerProductPageQueryQuery
+/**
+ * Sections: Components imported from '../components/sections' only.
+ * Do not import or render components from any other folder in here.
+ */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  ProductDetails,
+  BannerNewsletter,
+  CrossSellingShelf,
+}
 
-function Page({ product }: Props) {
+type Props = ServerProductPageQueryQuery & PDPContentType
+
+function Page({ product, sections }: Props) {
   const { currency } = useSession()
   const { seo } = product
   const title = seo.title || storeConfig.seo.title
@@ -84,27 +98,11 @@ function Page({ product }: Props) {
         If needed, wrap your component in a <Section /> component
         (not the HTML tag) before rendering it here.
       */}
-
-      <ProductDetails product={product} />
-
-      <ProductShelf
-        first={ITEMS_PER_SECTION}
-        selectedFacets={[
-          { key: 'buy', value: product.isVariantOf.productGroupID },
-        ]}
-        title="People also bought"
-        withDivisor
+      <RenderPageSections
+        context={product}
+        sections={sections}
+        components={COMPONENTS}
       />
-
-      <ProductShelf
-        first={ITEMS_PER_SECTION}
-        selectedFacets={[
-          { key: 'view', value: product.isVariantOf.productGroupID },
-        ]}
-        title="People also view"
-      />
-
-      <BannerNewsletter />
     </>
   )
 }
@@ -169,16 +167,23 @@ const query = gql`
 `
 
 export const getStaticProps: GetStaticProps<
-  ServerProductPageQueryQuery,
-  { slug: string }
-> = async ({ params }) => {
-  const { data, errors = [] } = await execute<
-    ServerProductPageQueryQueryVariables,
-    ServerProductPageQueryQuery
-  >({
-    variables: { slug: params?.slug ?? '' },
-    operationName: query,
-  })
+  Props,
+  { slug: string },
+  Locator
+> = async ({ params, previewData }) => {
+  const slug = params?.slug ?? ''
+  const [cmsPage, searchResult] = await Promise.all([
+    getPage<PDPContentType>({
+      ...previewData,
+      contentType: 'pdp',
+    }),
+    execute<ServerProductPageQueryQueryVariables, ServerProductPageQueryQuery>({
+      variables: { slug },
+      operationName: query,
+    }),
+  ])
+
+  const { data, errors = [] } = searchResult
 
   const notFound = errors.find(isNotFoundError)
 
@@ -193,7 +198,10 @@ export const getStaticProps: GetStaticProps<
   }
 
   return {
-    props: data,
+    props: {
+      ...data,
+      ...cmsPage,
+    },
   }
 }
 

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -174,7 +174,7 @@ export const getStaticProps: GetStaticProps<
   const slug = params?.slug ?? ''
   const [cmsPage, searchResult] = await Promise.all([
     getPage<PDPContentType>({
-      ...previewData,
+      ...(previewData?.contentType === 'pdp' ? previewData : null),
       contentType: 'pdp',
     }),
     execute<ServerProductPageQueryQueryVariables, ServerProductPageQueryQuery>({

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -79,7 +79,9 @@ export const getStaticProps: GetStaticProps<
   Locator
 > = async (context) => {
   const page = await getPage<PageContentType>({
-    ...(context.previewData ?? { filters: { 'settings.seo.slug': '/' } }),
+    ...(context.previewData?.contentType === 'page'
+      ? context.previewData
+      : { filters: { 'settings.seo.slug': '/' } }),
     contentType: 'page',
   })
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,33 @@
 import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
+import type { ComponentType } from 'react'
 import type { GetStaticProps } from 'next'
 import type { Locator } from '@vtex/client-cms'
 
 import RenderPageSections from 'src/components/cms/RenderPageSections'
-import type { PageContentType } from 'src/server/cms'
-import { getPage } from 'src/server/cms'
+import BannerText from 'src/components/sections/BannerText'
+import Hero from 'src/components/sections/Hero'
+import IncentivesHeader from 'src/components/sections/Incentives/IncentivesHeader'
+import Newsletter from 'src/components/sections/Newsletter'
+import ProductShelf from 'src/components/sections/ProductShelf'
+import ProductTiles from 'src/components/sections/ProductTiles'
 import { mark } from 'src/sdk/tests/mark'
+import { getPage } from 'src/server/cms'
+import type { PageContentType } from 'src/server/cms'
 
 import storeConfig from '../../store.config'
+
+/**
+ * Sections: Components imported from '../components/sections' only.
+ * Do not import or render components from any other folder in here.
+ */
+const COMPONENTS: Record<string, ComponentType<any>> = {
+  Hero,
+  BannerText,
+  IncentivesHeader,
+  ProductShelf,
+  ProductTiles,
+  Newsletter,
+}
 
 type Props = PageContentType
 
@@ -48,7 +68,7 @@ function Page({ sections, settings }: Props) {
         If needed, wrap your component in a <Section /> component
         (not the HTML tag) before rendering it here.
       */}
-      <RenderPageSections sections={sections} />
+      <RenderPageSections sections={sections} components={COMPONENTS} />
     </>
   )
 }

--- a/src/server/cms.ts
+++ b/src/server/cms.ts
@@ -1,5 +1,5 @@
 import ClientCMS from '@vtex/client-cms'
-import type { Locator, ContentData } from '@vtex/client-cms'
+import type { ContentData, Locator } from '@vtex/client-cms'
 
 import config from '../../store.config'
 
@@ -53,6 +53,8 @@ export const getPage = async <T extends ContentData>(options: Options) => {
 
   return pages[0] as T
 }
+
+export type PDPContentType = ContentData
 
 export type PageContentType = ContentData & {
   settings: {

--- a/store.config.js
+++ b/store.config.js
@@ -15,7 +15,7 @@ module.exports = {
   // Platform specific configs for API
   api: {
     storeId: 'storeframework',
-    workspace: 'gimenes',
+    workspace: 'master',
     environment: 'vtexcommercestable',
     hideUnavailableItems: true,
   },

--- a/store.config.js
+++ b/store.config.js
@@ -15,7 +15,7 @@ module.exports = {
   // Platform specific configs for API
   api: {
     storeId: 'storeframework',
-    workspace: 'master',
+    workspace: 'gimenes',
     environment: 'vtexcommercestable',
     hideUnavailableItems: true,
   },


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR is an RFC followed by an example implementation on how to  integrate the PDP with the CMS.  This implementation has several steps and some tradeoffs were made. I hope to clarify them in the next section

## How does it work?
The first step was to create a new content type called PDP. This content type is supposed to be a singleton, this means there can only be one single instance of this content-type on the CMS. 

To render CMS sections, `RenderPageSections` is usually used. The issue in here is that components like `ProductDetails` expect the `product` data fetched on `getStaticProps`. To address this issue I had two possibilities, either add `product` info into a `React.Context` at `p.tsx` and use this context inside `ProductDetails`, or change `RenderPageSections` to pass additional props to section components. I went with changing `RenderPageSections` because incoming server components feature does not support `React.Context`.  
To normalize the `RenderPageSections` API, I created a prop called `context`. This contains the getStaticProps data so ProductDetails can use product info.
A new componente called `CrossSellingShelf` was added respecting the product context and may only be instantiated on PDPs.

Finally, due to code splitting based on routes, I had to place the `COMPONENTS` map into each route and made the `RenderPageSections` accept a `components` prop accepting this map.

## How to test it?
Nothing should have changed. Open and change content in [here](https://gimenes--storeframework.myvtex.com/admin/new-cms/faststore/pdp/edit/717bc97f-8f19-4744-a52b-7ccac43cc898/). Run locally and make sure you see the content changing

