### PR TITLE
chore: Use faststore.dev for serving secure

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
 Disallow: /checkout/*
-Sitemap: https://vtexfaststore.com/sitemap/sitemap-index.xml
-Host: https://vtexfaststore.com
+Sitemap: https://demo.faststore.com/sitemap/sitemap-index.xml
+Host: https://demo.faststore.com

--- a/store.config.js
+++ b/store.config.js
@@ -34,11 +34,11 @@ module.exports = {
   },
 
   // Production URLs
-  storeUrl: 'https://vtexfaststore.com',
-  secureSubdomain: 'https://secure.vtexfaststore.com',
-  checkoutUrl: 'https://secure.vtexfaststore.com/checkout',
-  loginUrl: 'https://secure.vtexfaststore.com/api/io/login',
-  accountUrl: 'https://secure.vtexfaststore.com/api/io/account',
+  storeUrl: 'https://demo.faststore.com',
+  secureSubdomain: 'https://secure.demo.faststore.com',
+  checkoutUrl: 'https://secure.demo.faststore.com/checkout',
+  loginUrl: 'https://secure.demo.faststore.com/api/io/login',
+  accountUrl: 'https://secure.demo.faststore.com/api/io/account',
 
   // Lighthouse CI
   lighthouse: {


### PR DESCRIPTION
## What's the purpose of this pull request?
Uses the secure.faststore.dev for serving commerce systems

