### PR TITLE
fix: specifies exact typescript version to avoid breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "sass-loader": "^12.6.0",
     "style-loader": "^3.3.1",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
-    "typescript": "^4.7.3"
+    "typescript": "4.7.3"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16618,7 +16618,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.7.3:
+typescript@4.7.3:
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
   integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR changes package.json to specify the exact typescript version to be used. The `typescript` package is released in such a way that minor bumps can contain breaking changes. Defining it as `ˆ{version}` opens the possibility of yarn/npm installing a new minor version containing breaking changes, which can prevent the project (or projects that depends on `@faststore/core`) from being built.

This isn't a problem in this repo because `yarn.lock` locks the version on the one specified in package.json, but that doesn't happen when this package is installed by other projects.

## How does it work?

This PR changes package.json to specify the exact typescript version to be used, removing the possibility of bumping minors and fixes automatically when the package is installed.

## How to test it?

The store should be built and work as before.

## References

https://github.com/microsoft/TypeScript/issues/14116