### PR TITLE
fix: custom components on home page

### DIFF
--- a/src/customizations/components/index.ts
+++ b/src/customizations/components/index.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/src/customizations/index.ts
+++ b/src/customizations/index.ts
@@ -1,1 +1,0 @@
-export default {}

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -1,24 +1,24 @@
 import { isNotFoundError } from '@faststore/api'
 import { gql } from '@faststore/graphql-utils'
-import { BreadcrumbJsonLd, NextSeo, ProductJsonLd } from 'next-seo'
-import type { GetStaticPaths, GetStaticProps } from 'next'
-import type { ComponentType } from 'react'
 import type { Locator } from '@vtex/client-cms'
+import type { GetStaticPaths, GetStaticProps } from 'next'
+import { BreadcrumbJsonLd, NextSeo, ProductJsonLd } from 'next-seo'
+import type { ComponentType } from 'react'
 
-import RenderPageSections from 'src/components/cms/RenderPageSections'
-import BannerNewsletter from 'src/components/sections/BannerNewsletter/BannerNewsletter'
-import CrossSellingShelf from 'src/components/sections/CrossSellingShelf'
-import ProductDetails from 'src/components/sections/ProductDetails'
-import { useSession } from 'src/sdk/session'
-import { mark } from 'src/sdk/tests/mark'
-import { execute } from 'src/server'
-import { getPage } from 'src/server/cms'
-import type { PDPContentType } from 'src/server/cms'
-import CUSTOM_SECTIONS from 'src/customizations'
 import type {
   ServerProductPageQueryQuery,
   ServerProductPageQueryQueryVariables,
 } from '@generated/graphql'
+import RenderPageSections from 'src/components/cms/RenderPageSections'
+import BannerNewsletter from 'src/components/sections/BannerNewsletter/BannerNewsletter'
+import CrossSellingShelf from 'src/components/sections/CrossSellingShelf'
+import ProductDetails from 'src/components/sections/ProductDetails'
+import CUSTOM_COMPONENTS from 'src/customizations/components'
+import { useSession } from 'src/sdk/session'
+import { mark } from 'src/sdk/tests/mark'
+import { execute } from 'src/server'
+import type { PDPContentType } from 'src/server/cms'
+import { getPage } from 'src/server/cms'
 
 import storeConfig from '../../../store.config'
 
@@ -30,7 +30,7 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   ProductDetails,
   BannerNewsletter,
   CrossSellingShelf,
-  ...CUSTOM_SECTIONS,
+  ...CUSTOM_COMPONENTS,
 }
 
 type Props = ServerProductPageQueryQuery & PDPContentType

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
+import type { Locator } from '@vtex/client-cms'
+import type { GetStaticProps } from 'next'
 import { NextSeo, SiteLinksSearchBoxJsonLd } from 'next-seo'
 import type { ComponentType } from 'react'
-import type { GetStaticProps } from 'next'
-import type { Locator } from '@vtex/client-cms'
 
 import RenderPageSections from 'src/components/cms/RenderPageSections'
 import BannerText from 'src/components/sections/BannerText'
@@ -10,17 +10,14 @@ import IncentivesHeader from 'src/components/sections/Incentives/IncentivesHeade
 import Newsletter from 'src/components/sections/Newsletter'
 import ProductShelf from 'src/components/sections/ProductShelf'
 import ProductTiles from 'src/components/sections/ProductTiles'
+import CUSTOM_COMPONENTS from 'src/customizations/components'
 import { mark } from 'src/sdk/tests/mark'
-import { getPage } from 'src/server/cms'
 import type { PageContentType } from 'src/server/cms'
-import CUSTOM_SECTIONS from 'src/customizations'
+import { getPage } from 'src/server/cms'
 
 import storeConfig from '../../store.config'
 
-/**
- * Sections: Components imported from each store's custom components and '../components/sections'.
- * Do not import or render components from any other folder in here.
- */
+/* A list of components that can be used in the CMS. */
 const COMPONENTS: Record<string, ComponentType<any>> = {
   Hero,
   BannerText,
@@ -28,7 +25,7 @@ const COMPONENTS: Record<string, ComponentType<any>> = {
   ProductShelf,
   ProductTiles,
   Newsletter,
-  ...CUSTOM_SECTIONS,
+  ...CUSTOM_COMPONENTS,
 }
 
 type Props = PageContentType


### PR DESCRIPTION
## What's the purpose of this pull request?

`faststore/cli` copies everything in the src folder, however, the home page tries to import the index from `src` and not from components, and this PR fixes that.
 
## How does it work?

Just fix the import path.

## How to test it?

<em>Describe the steps with bullet points. Is there any external reference, link, or example?</em>

## References

<em>Spread the knowledge: is any content you used to create this PR worth sharing?</em>

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em>

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**
- [ ] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [ ] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`
- [ ] Added the component, hook, or path name in-between backticks (\`\`) - *if applicable, e.g., `ComponentName` component, `useWindowDimensions` hook*

**Dependencies**
- [ ] Committed the `yarn.lock` and `bun.lockb` file when there were changes to the packages

**Documentation**
- [ ] PR description
- [ ] Added to/Updated the Storybook - *if applicable*
- [ ] For documentation changes, ping `@carolinamenezes` or `@PedroAntunesCosta` to review and update
