### PR TITLE
chore: remove vtex tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@faststore/ui": "^2.0.17-alpha.0",
     "@types/react": "^18.0.14",
     "@vtex/client-cms": "^0.2.12",
-    "@vtex/tsconfig": "0.6.0",
     "autoprefixer": "^10.4.0",
     "css-loader": "^6.7.1",
     "eslint": "^7.22.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "@vtex/tsconfig",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3920,11 +3920,6 @@
   resolved "https://registry.yarnpkg.com/@vtex/prettier-config/-/prettier-config-1.0.0.tgz#a7a7091ecff1da340d398000f4855dc9910aa9c9"
   integrity sha512-4Uv67bK2eORhzWg/11J5/+fxPUWY6b0sYdhcqMzIgo0zluXlYqbZU6iueKZ48SxG4ODw8ZaqMRfpNsLd3Gw5+Q==
 
-"@vtex/tsconfig@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.6.0.tgz#c9dfffc95d2ef55195237411f9c15269ca30b2a5"
-  integrity sha512-SVQBxaSdEVdpJFja1aVTIiZBgpQKePyYOUWGzcYq6LYkSWqSbz2LoC7TuLUsmfweYmVkv8+4eVuxcDpQVEpq1A==
-
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"


### PR DESCRIPTION
## What's the purpose of this pull request?

We don't need to use this configuration anymore, `@vtex/tsconfig` is deprecated.

## How does it work?

<em>Tell us the role of the new feature, or component, in its context.</em>

## How to test it?

<em>Describe the steps with bullet points. Is there any external reference, link, or example?</em>

## References

<em>Spread the knowledge: is any content you used to create this PR worth sharing?</em>

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em>

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**
- [ ] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [ ] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`
- [ ] Added the component, hook, or path name in-between backticks (\`\`) - *if applicable, e.g., `ComponentName` component, `useWindowDimensions` hook*

**Dependencies**
- [ ] Committed the `yarn.lock` and `bun.lockb` file when there were changes to the packages

**Documentation**
- [ ] PR description
- [ ] Added to/Updated the Storybook - *if applicable*
- [ ] For documentation changes, ping `@carolinamenezes` or `@PedroAntunesCosta` to review and update
