### PR TITLE
chore: improve log message when component not found in cms

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/react": "^18.0.14",
     "@vtex/client-cms": "^0.2.12",
     "autoprefixer": "^10.4.0",
+    "chalk": "^5.2.0",
     "css-loader": "^6.7.1",
     "eslint": "^7.22.0",
     "eslint-config-next": "12.1.5",

--- a/src/components/cms/RenderPageSections.tsx
+++ b/src/components/cms/RenderPageSections.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import chalk from 'chalk'
 import type { ComponentType } from 'react'
 
 import SectionBoundary from './SectionBoundary'
@@ -15,11 +16,14 @@ const RenderPageSections = ({ sections = [], context, components }: Props) => (
       const Component = components[name]
 
       if (!Component) {
+        // TODO: add a documentation link to help to do this
         console.info(
-          `Could not find component for block ${name}. Add a new component for this block or remove it from the CMS`
+          `${chalk.yellow(
+            'warn'
+          )} - ${name} not found. Add a new component for this section or remove it from the CMS`
         )
 
-        return <></>
+        return null
       }
 
       return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5785,6 +5785,11 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
+  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
+
 change-case-all@1.0.14:
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/change-case-all/-/change-case-all-1.0.14.tgz#bac04da08ad143278d0ac3dda7eccd39280bfba1"


### PR DESCRIPTION
## What's the purpose of this pull request?

When exists a Section on CMS, but the store doesn't have a component to render that, this log is shown:

```cmd
Could not find the component for block HelloWorld. Add a new component for this block or remove it from the CMS
Warning: Each child in a list should have a unique "key" prop. See https://reactjs.org/link/warning-keys for more information.
```

So, this PR improves this message and prevents key errors.

![Screenshot 2022-12-19 at 17 08 40](https://user-images.githubusercontent.com/10627086/208511344-5e731ae9-f9d7-40f4-b1a6-8e767832b109.png)


## How does it work?

return null avoid fragment avoids the need to add key

## How to test it?

<em>Describe the steps with bullet points. Is there any external reference, link, or example?</em>

## References

<em>Spread the knowledge: is any content you used to create this PR worth sharing?</em>

<em>Extra tip: add references to related issues or mention people important to this PR may be good for the documentation and reviewing process</em>

## Checklist

<em>You may erase this after checking them all :wink:</em>

**PR Title and Commit Messages**
- [ ] PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
  - Available prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`

**PR Description**
- [ ] Added a label according to the PR goal - `Breaking change`, `Features`, `Bug fixes`, `Chore`, `Documentation`, `Style changes`, `Refactoring`, `Performance`, and `Test`
- [ ] Added the component, hook, or path name in-between backticks (\`\`) - *if applicable, e.g., `ComponentName` component, `useWindowDimensions` hook*

**Dependencies**
- [ ] Committed the `yarn.lock` and `bun.lockb` file when there were changes to the packages

**Documentation**
- [ ] PR description
- [ ] Added to/Updated the Storybook - *if applicable*
- [ ] For documentation changes, ping `@carolinamenezes` or `@PedroAntunesCosta` to review and update
