### PR TITLE
Add an /api/health endpoint for readiness probe

### DIFF
--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,5 +1,5 @@
-import type { NextApiRequest } from 'next'
+import type { NextApiRequest, NextApiResponse } from 'next'
 
-export default function handler(_req: NextApiRequest, res) {
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
   res.status(200).send('OK')
 }

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest } from 'next'
+
+export default function handler(_req: NextApiRequest, res) {
+  res.status(200).send('OK')
+}

--- a/src/pages/api/health/live.ts
+++ b/src/pages/api/health/live.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+/**
+ * This is equal to the /api/health/ready endpoint for lack of a better
+ * implementation differentiating between them.
+ */
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).send('OK')
+}

--- a/src/pages/api/health/ready.ts
+++ b/src/pages/api/health/ready.ts
@@ -1,5 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
+/**
+ * This is equal to the /api/health/live endpoint for lack of a better
+ * implementation differentiating between them.
+ */
 export default function handler(_req: NextApiRequest, res: NextApiResponse) {
   res.status(200).send('OK')
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

After @cezar-guimaraes request that we add a route to be used by the readiness probe. I **believe** the liveness probe should be on the nginx layer and therefore will be made in a separate PR.

## How does it work?

An application endpoint that responds 200 (and the OK text) to whoever calls it.

## How to test it?

Run the store and hit localhost:3000/api/health
