### PR TITLE
Fix: PLP reset pagination when navigating to another PLP

### DIFF
--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -150,11 +150,12 @@ export const getStaticProps: GetStaticProps<
   ServerCollectionPageQueryQuery,
   { slug: string[] }
 > = async ({ params }) => {
+  const slug = params?.slug.join('/') ?? ''
   const { data, errors = [] } = await execute<
     ServerCollectionPageQueryQueryVariables,
     ServerCollectionPageQueryQuery
   >({
-    variables: { slug: params?.slug.join('/') ?? '' },
+    variables: { slug },
     operationName: query,
   })
 
@@ -171,7 +172,10 @@ export const getStaticProps: GetStaticProps<
   }
 
   return {
-    props: data,
+    props: {
+      ...data,
+      key: slug,
+    },
   }
 }
 

--- a/src/pages/[slug]/p.tsx
+++ b/src/pages/[slug]/p.tsx
@@ -203,6 +203,7 @@ export const getStaticProps: GetStaticProps<
     props: {
       ...data,
       ...cmsPage,
+      key: slug,
     },
   }
 }


### PR DESCRIPTION
## What's the purpose of this pull request?

- It fixes the bug to reset pagination when navigating to another PLP

## How does it work?

Adds key prop to identify the different PLP and PDP pages will reset the component tree’s state.

## How to test it?

https://github.com/vtex-sites/nextjs.store/assets/3356699/39d2f633-5315-472b-9198-c04dbd424f84


#### PLP
1. In the `Office` category
2. Click in `Load more products`
3. Go to `Technology` category
4. You should be in the first page.
 
___ 

#### PDP
1. Go to any PDP;
2. Increase the product's quantity;
3. Click on any product inside the "People also bought" section".
4. The product's quantity should be 1.

## References

Applied changes from this 2 PRs:
https://github.com/vtex/faststore/pull/2045
https://github.com/vtex/faststore/pull/2043

